### PR TITLE
Dummy

### DIFF
--- a/.idea/.name
+++ b/.idea/.name
@@ -1,0 +1,1 @@
+Skylight

--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -4,6 +4,7 @@
     <modules>
       <module fileurl="file://$PROJECT_DIR$/Skylight.iml" filepath="$PROJECT_DIR$/Skylight.iml" />
       <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
+      <module fileurl="file://$PROJECT_DIR$/dummy/dummy.iml" filepath="$PROJECT_DIR$/dummy/dummy.iml" />
       <module fileurl="file://$PROJECT_DIR$/rx/rx.iml" filepath="$PROJECT_DIR$/rx/rx.iml" />
       <module fileurl="file://$PROJECT_DIR$/skylight/skylight.iml" filepath="$PROJECT_DIR$/skylight/skylight.iml" />
       <module fileurl="file://$PROJECT_DIR$/sso/sso.iml" filepath="$PROJECT_DIR$/sso/sso.iml" />

--- a/README.md
+++ b/README.md
@@ -12,10 +12,13 @@ To use Skylight, include any of the following in your Gradle dependencies:
 ```groovy
 // The base interface:
 implementation "drewhamilton.skylight:skylight:$version"
-// RxJava extensions:
+// RxJava extensions for any Skylight implementation:
 implementation "drewhamilton.skylight:skylight-rx:$version"
 // sunrise-sunset.org implementation:
 implementation "drewhamilton.skylight:skylight-sso:$version"
+// Dummy implementation:
+implementation "drewhamilton.skylight:skylight-dummy:$version"
+
 // Android views:
 implementation "drewhamilton.skylight:skylight-views:$version"
 ```
@@ -33,6 +36,9 @@ An implementation of the interface that uses [sunrise-sunset.org](https://sunris
 publicly available [API](https://sunrise-sunset.org/api) to determine skylight information. Note that
 sunrise-sunset.org's API page says that "You may not use this API in a manner that exceeds reasonable request volume,
 constitutes excessive or abusive usage." The same requirement applies to this module of Skylight.
+
+### `:dummy`
+An implementation that just returns the same set of skylight information regardless of coordinate and date inputs.
 
 ### `:views`
 For Android: Skylight themes and a basic card view that can be used to display a skylight event.

--- a/dummy/build.gradle
+++ b/dummy/build.gradle
@@ -1,0 +1,12 @@
+apply plugin: 'java-library'
+apply plugin: 'kotlin'
+apply plugin: 'kotlin-kapt'
+
+dependencies {
+    implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
+
+    api project(':skylight')
+}
+
+sourceCompatibility = "1.8"
+targetCompatibility = "1.8"

--- a/dummy/build.gradle
+++ b/dummy/build.gradle
@@ -6,6 +6,8 @@ dependencies {
     implementation "org.jetbrains.kotlin:kotlin-stdlib:$kotlin_version"
 
     api project(':skylight')
+
+    testImplementation 'junit:junit:4.12'
 }
 
 sourceCompatibility = "1.8"

--- a/dummy/src/main/java/drewhamilton/skylight/dummy/DummySkylight.kt
+++ b/dummy/src/main/java/drewhamilton/skylight/dummy/DummySkylight.kt
@@ -9,12 +9,12 @@ import java.util.Date
  * A [Skylight] implementation that ignores passed parameters, and instead returns specific set values.
  */
 class DummySkylight(
-    private val dummySkylightDay: SkylightDay
+    val skylightDay: SkylightDay
 ) : Skylight {
     /**
      * @param coordinates ignored.
      * @param date ignored.
      * @return the dummy [SkylightDay] passed to the constructor.
      */
-    override fun getSkylightDay(coordinates: Coordinates, date: Date) = dummySkylightDay
+    override fun getSkylightDay(coordinates: Coordinates, date: Date) = skylightDay
 }

--- a/dummy/src/main/java/drewhamilton/skylight/dummy/DummySkylight.kt
+++ b/dummy/src/main/java/drewhamilton/skylight/dummy/DummySkylight.kt
@@ -1,0 +1,20 @@
+package drewhamilton.skylight.dummy
+
+import drewhamilton.skylight.Coordinates
+import drewhamilton.skylight.Skylight
+import drewhamilton.skylight.SkylightDay
+import java.util.Date
+
+/**
+ * A [Skylight] implementation that ignores passed parameters, and instead returns specific set values.
+ */
+class DummySkylight(
+    private val dummySkylightDay: SkylightDay
+) : Skylight {
+    /**
+     * @param coordinates ignored.
+     * @param date ignored.
+     * @return the dummy [SkylightDay] passed to the constructor.
+     */
+    override fun getSkylightDay(coordinates: Coordinates, date: Date) = dummySkylightDay
+}

--- a/dummy/src/test/java/drewhamilton/skylight/dummy/DummySkylightTest.kt
+++ b/dummy/src/test/java/drewhamilton/skylight/dummy/DummySkylightTest.kt
@@ -1,0 +1,34 @@
+package drewhamilton.skylight.dummy
+
+import drewhamilton.skylight.Coordinates
+import drewhamilton.skylight.SkylightDay
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Test
+import java.util.Date
+
+class DummySkylightTest {
+
+    private val testSkylightDay: SkylightDay = SkylightDay.Typical(Date(1), Date(2), Date(3), Date(4))
+
+    private lateinit var dummySkylight: DummySkylight
+
+    @Before
+    fun setUp() {
+        dummySkylight = DummySkylight(testSkylightDay)
+    }
+
+    @Test
+    fun `getSkylightInfo returns SkylightDay from constructor`() {
+        val result1 = dummySkylight.getSkylightDay(Coordinates(0.0, 0.0), Date(1))
+        assertEquals(testSkylightDay, result1)
+
+        val result2 = dummySkylight.getSkylightDay(Coordinates(90.0, 180.0), Date(999999999999999))
+        assertEquals(testSkylightDay, result2)
+    }
+
+    @Test
+    fun `skylightDay property equals value from constructor`() {
+        assertEquals(testSkylightDay, dummySkylight.skylightDay)
+    }
+}

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,1 +1,1 @@
-include ':app', ':skylight', ':sso', ':views', ':rx'
+include ':app', ':skylight', ':sso', ':views', ':rx', ':dummy'


### PR DESCRIPTION
Add `DummySkylight`, an implementation that returns the same `SkylightDay` regardless of coordinate and date inputs.