### PR TITLE
Dummy date enhancement

### DIFF
--- a/dummy-backport/src/main/java/drewhamilton/skylight/backport/dummy/DummySkylight.kt
+++ b/dummy-backport/src/main/java/drewhamilton/skylight/backport/dummy/DummySkylight.kt
@@ -7,17 +7,38 @@ import org.threeten.bp.LocalDate
 import javax.inject.Inject
 
 /**
- * A [Skylight] implementation that ignores passed parameters, and instead returns specific set values.
+ * A [Skylight] implementation that ignores the coordinates parameter, and instead returns a copy of a specific
+ * [SkylightDay] for the given date parameter.
  */
 class DummySkylight @Inject constructor(
+    // TODO: Make this public?
     private val dummySkylightDay: SkylightDay
 ) : Skylight {
 
-    override fun getSkylightDay(coordinates: Coordinates, date: LocalDate) = dummySkylightDay
+    /**
+     * Get a copy of the [SkylightDay] originally passed to the constructor for the given [date]. [coordinates] are
+     * always ignored.
+     */
+    override fun getSkylightDay(coordinates: Coordinates, date: LocalDate) = getSkylightDay(date)
 
     /**
-     * A convenience overload of [getSkylightDay] with ignored parameters removed.
-     * @return the dummy [SkylightDay] passed to the constructor.
+     * Get a copy of the [SkylightDay] originally passed to the constructor for the given [date].
      */
+    fun getSkylightDay(date: LocalDate) = dummySkylightDay.copy(date)
+
+    /**
+     * Get the dummy [SkylightDay] passed to the constructor.
+     */
+    @Deprecated("The date parameter is no longer ignored, so this overload is unwanted.")
     fun getSkylightDay() = dummySkylightDay
+
+    private fun SkylightDay.copy(date: LocalDate = this.date): SkylightDay {
+        return when (this) {
+            is SkylightDay.Typical -> copy(date = date)
+            is SkylightDay.AlwaysDaytime -> copy(date = date)
+            is SkylightDay.AlwaysLight -> copy(date = date)
+            is SkylightDay.NeverDaytime -> copy(date = date)
+            is SkylightDay.NeverLight -> copy(date = date)
+        }
+    }
 }

--- a/dummy-backport/src/main/java/drewhamilton/skylight/backport/dummy/DummySkylight.kt
+++ b/dummy-backport/src/main/java/drewhamilton/skylight/backport/dummy/DummySkylight.kt
@@ -26,12 +26,6 @@ class DummySkylight @Inject constructor(
      */
     fun getSkylightDay(date: LocalDate) = dummySkylightDay.copy(date)
 
-    /**
-     * Get the dummy [SkylightDay] passed to the constructor.
-     */
-    @Deprecated("The date parameter is no longer ignored, so this overload is unwanted.")
-    fun getSkylightDay() = dummySkylightDay
-
     private fun SkylightDay.copy(date: LocalDate = this.date): SkylightDay {
         return when (this) {
             is SkylightDay.Typical -> copy(date = date)

--- a/dummy-backport/src/test/java/drewhamilton/skylight/backport/dummy/DummySkylightTest.kt
+++ b/dummy-backport/src/test/java/drewhamilton/skylight/backport/dummy/DummySkylightTest.kt
@@ -27,16 +27,35 @@ class DummySkylightTest {
     }
 
     @Test
-    fun `getSkylightInfo returns SkylightDay from constructor`() {
+    fun `getSkylightInfo(Coordinates, LocalDate) returns copy of SkylightDay from constructor with changed date`() {
         val result1 = dummySkylight.getSkylightDay(Coordinates(0.0, 0.0), LocalDate.MIN)
-        Assert.assertEquals(testSkylightDay, result1)
+        Assert.assertEquals(LocalDate.MIN, result1.date)
+        Assert.assertTrue(result1 is SkylightDay.Typical)
+        result1 as SkylightDay.Typical
+        Assert.assertEquals(testSkylightDay.dawn, result1.dawn)
+        Assert.assertEquals(testSkylightDay.sunrise, result1.sunrise)
+        Assert.assertEquals(testSkylightDay.sunset, result1.sunset)
+        Assert.assertEquals(testSkylightDay.dawn, result1.dawn)
 
         val result2 = dummySkylight.getSkylightDay(Coordinates(90.0, 180.0), LocalDate.MAX)
-        Assert.assertEquals(testSkylightDay, result2)
+        Assert.assertEquals(LocalDate.MAX, result2.date)
+        Assert.assertTrue(result2 is SkylightDay.Typical)
+        result2 as SkylightDay.Typical
+        Assert.assertEquals(testSkylightDay.dawn, result2.dawn)
+        Assert.assertEquals(testSkylightDay.sunrise, result2.sunrise)
+        Assert.assertEquals(testSkylightDay.sunset, result2.sunset)
+        Assert.assertEquals(testSkylightDay.dawn, result2.dawn)
     }
 
-    @Test
-    fun `skylightDay property equals value from constructor`() {
-        Assert.assertEquals(testSkylightDay, dummySkylight.getSkylightDay())
+    @Test fun `getSkylightInfo(LocalDate) returns copy of SkylightDay from constructor with changed date`() {
+        val testDate = LocalDate.ofEpochDay(6343)
+        val result = dummySkylight.getSkylightDay(testDate)
+        Assert.assertEquals(testDate, result.date)
+        Assert.assertTrue(result is SkylightDay.Typical)
+        result as SkylightDay.Typical
+        Assert.assertEquals(testSkylightDay.dawn, result.dawn)
+        Assert.assertEquals(testSkylightDay.sunrise, result.sunrise)
+        Assert.assertEquals(testSkylightDay.sunset, result.sunset)
+        Assert.assertEquals(testSkylightDay.dawn, result.dawn)
     }
 }

--- a/dummy-backport/src/test/java/drewhamilton/skylight/backport/dummy/dagger/DummySkylightComponentTest.kt
+++ b/dummy-backport/src/test/java/drewhamilton/skylight/backport/dummy/dagger/DummySkylightComponentTest.kt
@@ -7,13 +7,14 @@ import org.threeten.bp.LocalDate
 
 class DummySkylightComponentTest {
 
-    private val testSkylightDay = SkylightDay.NeverLight(LocalDate.ofEpochDay(4))
+    private val testDate = LocalDate.ofEpochDay(4)
+    private val testSkylightDay = SkylightDay.NeverLight(testDate)
 
     @Test
     fun `create returns DummySkylightComponent with dummySkylightDay`() {
         val dummySkylightComponent = DummySkylightComponent.create(testSkylightDay)
         val skylight = dummySkylightComponent.skylight()
 
-        assertEquals(testSkylightDay, skylight.getSkylightDay())
+        assertEquals(testSkylightDay, skylight.getSkylightDay(testDate))
     }
 }

--- a/dummy/src/main/java/drewhamilton/skylight/dummy/DummySkylight.kt
+++ b/dummy/src/main/java/drewhamilton/skylight/dummy/DummySkylight.kt
@@ -1,23 +1,38 @@
 package drewhamilton.skylight.dummy
 
 import drewhamilton.skylight.Coordinates
-import drewhamilton.skylight.SkylightDay
 import drewhamilton.skylight.Skylight
+import drewhamilton.skylight.SkylightDay
 import java.time.LocalDate
 import javax.inject.Inject
 
 /**
- * A [Skylight] implementation that ignores passed parameters, and instead returns specific set values.
+ * A [Skylight] implementation that ignores the coordinates parameter, and instead returns a copy of a specific
+ * [SkylightDay] for the given date parameter.
  */
 class DummySkylight @Inject constructor(
+    // TODO: Make this public?
     private val dummySkylightDay: SkylightDay
 ) : Skylight {
 
-    override fun getSkylightDay(coordinates: Coordinates, date: LocalDate) = dummySkylightDay
+    /**
+     * Get a copy of the [SkylightDay] originally passed to the constructor for the given [date]. [coordinates] are
+     * always ignored.
+     */
+    override fun getSkylightDay(coordinates: Coordinates, date: LocalDate) = getSkylightDay(date)
 
     /**
-     * A convenience overload of [getSkylightDay] with ignored parameters removed.
-     * @return the dummy [SkylightDay] passed to the constructor.
+     * Get a copy of the [SkylightDay] originally passed to the constructor for the given [date].
      */
-    fun getSkylightDay() = dummySkylightDay
+    fun getSkylightDay(date: LocalDate) = dummySkylightDay.copy(date)
+
+    private fun SkylightDay.copy(date: LocalDate = this.date): SkylightDay {
+        return when (this) {
+            is SkylightDay.Typical -> copy(date = date)
+            is SkylightDay.AlwaysDaytime -> copy(date = date)
+            is SkylightDay.AlwaysLight -> copy(date = date)
+            is SkylightDay.NeverDaytime -> copy(date = date)
+            is SkylightDay.NeverLight -> copy(date = date)
+        }
+    }
 }

--- a/dummy/src/test/java/drewhamilton/skylight/dummy/DummySkylightTest.kt
+++ b/dummy/src/test/java/drewhamilton/skylight/dummy/DummySkylightTest.kt
@@ -3,6 +3,7 @@ package drewhamilton.skylight.dummy
 import drewhamilton.skylight.Coordinates
 import drewhamilton.skylight.SkylightDay
 import org.junit.Assert.assertEquals
+import org.junit.Assert.assertTrue
 import org.junit.Before
 import org.junit.Test
 import java.time.LocalDate
@@ -27,16 +28,35 @@ class DummySkylightTest {
     }
 
     @Test
-    fun `getSkylightInfo returns SkylightDay from constructor`() {
+    fun `getSkylightInfo(Coordinates, LocalDate) returns copy of SkylightDay from constructor with changed date`() {
         val result1 = dummySkylight.getSkylightDay(Coordinates(0.0, 0.0), LocalDate.MIN)
-        assertEquals(testSkylightDay, result1)
+        assertEquals(LocalDate.MIN, result1.date)
+        assertTrue(result1 is SkylightDay.Typical)
+        result1 as SkylightDay.Typical
+        assertEquals(testSkylightDay.dawn, result1.dawn)
+        assertEquals(testSkylightDay.sunrise, result1.sunrise)
+        assertEquals(testSkylightDay.sunset, result1.sunset)
+        assertEquals(testSkylightDay.dawn, result1.dawn)
 
         val result2 = dummySkylight.getSkylightDay(Coordinates(90.0, 180.0), LocalDate.MAX)
-        assertEquals(testSkylightDay, result2)
+        assertEquals(LocalDate.MAX, result2.date)
+        assertTrue(result2 is SkylightDay.Typical)
+        result2 as SkylightDay.Typical
+        assertEquals(testSkylightDay.dawn, result2.dawn)
+        assertEquals(testSkylightDay.sunrise, result2.sunrise)
+        assertEquals(testSkylightDay.sunset, result2.sunset)
+        assertEquals(testSkylightDay.dawn, result2.dawn)
     }
 
-    @Test
-    fun `skylightDay property equals value from constructor`() {
-        assertEquals(testSkylightDay, dummySkylight.getSkylightDay())
+    @Test fun `getSkylightInfo(LocalDate) returns copy of SkylightDay from constructor with changed date`() {
+        val testDate = LocalDate.ofEpochDay(6343)
+        val result = dummySkylight.getSkylightDay(testDate)
+        assertEquals(testDate, result.date)
+        assertTrue(result is SkylightDay.Typical)
+        result as SkylightDay.Typical
+        assertEquals(testSkylightDay.dawn, result.dawn)
+        assertEquals(testSkylightDay.sunrise, result.sunrise)
+        assertEquals(testSkylightDay.sunset, result.sunset)
+        assertEquals(testSkylightDay.dawn, result.dawn)
     }
 }

--- a/dummy/src/test/java/drewhamilton/skylight/dummy/dagger/DummySkylightComponentTest.kt
+++ b/dummy/src/test/java/drewhamilton/skylight/dummy/dagger/DummySkylightComponentTest.kt
@@ -7,13 +7,14 @@ import java.time.LocalDate
 
 class DummySkylightComponentTest {
 
-    private val testSkylightDay = SkylightDay.NeverLight(LocalDate.ofEpochDay(4))
+    private val testDate = LocalDate.ofEpochDay(4)
+    private val testSkylightDay = SkylightDay.NeverLight(testDate)
 
     @Test
     fun `create returns DummySkylightComponent with dummySkylightDay`() {
         val dummySkylightComponent = DummySkylightComponent.create(testSkylightDay)
         val skylight = dummySkylightComponent.skylight()
 
-        assertEquals(testSkylightDay, skylight.getSkylightDay())
+        assertEquals(testSkylightDay, skylight.getSkylightDay(testDate))
     }
 }


### PR DESCRIPTION
Ensure the SkylightDay returned by DummySkylight always includes the same date as was passed into the function. Achieve this by copying the data to a new instance with the correct date.