### PR TITLE
Use default time zone in view extensions

### DIFF
--- a/.idea/modules.xml
+++ b/.idea/modules.xml
@@ -2,19 +2,19 @@
 <project version="4">
   <component name="ProjectModuleManager">
     <modules>
-      <module fileurl="file://$PROJECT_DIR$/Skylight.iml" filepath="$PROJECT_DIR$/Skylight.iml" />
-      <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" />
-      <module fileurl="file://$PROJECT_DIR$/calculator/calculator.iml" filepath="$PROJECT_DIR$/calculator/calculator.iml" />
-      <module fileurl="file://$PROJECT_DIR$/calculator-backport/calculator-backport.iml" filepath="$PROJECT_DIR$/calculator-backport/calculator-backport.iml" />
-      <module fileurl="file://$PROJECT_DIR$/dummy/dummy.iml" filepath="$PROJECT_DIR$/dummy/dummy.iml" />
-      <module fileurl="file://$PROJECT_DIR$/dummy-backport/dummy-backport.iml" filepath="$PROJECT_DIR$/dummy-backport/dummy-backport.iml" />
-      <module fileurl="file://$PROJECT_DIR$/rx/rx.iml" filepath="$PROJECT_DIR$/rx/rx.iml" />
-      <module fileurl="file://$PROJECT_DIR$/rx-backport/rx-backport.iml" filepath="$PROJECT_DIR$/rx-backport/rx-backport.iml" />
-      <module fileurl="file://$PROJECT_DIR$/skylight/skylight.iml" filepath="$PROJECT_DIR$/skylight/skylight.iml" />
-      <module fileurl="file://$PROJECT_DIR$/skylight-backport/skylight-backport.iml" filepath="$PROJECT_DIR$/skylight-backport/skylight-backport.iml" />
-      <module fileurl="file://$PROJECT_DIR$/sso/sso.iml" filepath="$PROJECT_DIR$/sso/sso.iml" />
-      <module fileurl="file://$PROJECT_DIR$/sso-backport/sso-backport.iml" filepath="$PROJECT_DIR$/sso-backport/sso-backport.iml" />
-      <module fileurl="file://$PROJECT_DIR$/views/views.iml" filepath="$PROJECT_DIR$/views/views.iml" />
+      <module fileurl="file://$PROJECT_DIR$/Skylight.iml" filepath="$PROJECT_DIR$/Skylight.iml" group="Skylight" />
+      <module fileurl="file://$PROJECT_DIR$/app/app.iml" filepath="$PROJECT_DIR$/app/app.iml" group="Skylight/app" />
+      <module fileurl="file://$PROJECT_DIR$/calculator/calculator.iml" filepath="$PROJECT_DIR$/calculator/calculator.iml" group="Skylight/calculator" />
+      <module fileurl="file://$PROJECT_DIR$/calculator-backport/calculator-backport.iml" filepath="$PROJECT_DIR$/calculator-backport/calculator-backport.iml" group="Skylight/calculator-backport" />
+      <module fileurl="file://$PROJECT_DIR$/dummy/dummy.iml" filepath="$PROJECT_DIR$/dummy/dummy.iml" group="Skylight/dummy" />
+      <module fileurl="file://$PROJECT_DIR$/dummy-backport/dummy-backport.iml" filepath="$PROJECT_DIR$/dummy-backport/dummy-backport.iml" group="Skylight/dummy-backport" />
+      <module fileurl="file://$PROJECT_DIR$/rx/rx.iml" filepath="$PROJECT_DIR$/rx/rx.iml" group="Skylight/rx" />
+      <module fileurl="file://$PROJECT_DIR$/rx-backport/rx-backport.iml" filepath="$PROJECT_DIR$/rx-backport/rx-backport.iml" group="Skylight/rx-backport" />
+      <module fileurl="file://$PROJECT_DIR$/skylight/skylight.iml" filepath="$PROJECT_DIR$/skylight/skylight.iml" group="Skylight/skylight" />
+      <module fileurl="file://$PROJECT_DIR$/skylight-backport/skylight-backport.iml" filepath="$PROJECT_DIR$/skylight-backport/skylight-backport.iml" group="Skylight/skylight-backport" />
+      <module fileurl="file://$PROJECT_DIR$/sso/sso.iml" filepath="$PROJECT_DIR$/sso/sso.iml" group="Skylight/sso" />
+      <module fileurl="file://$PROJECT_DIR$/sso-backport/sso-backport.iml" filepath="$PROJECT_DIR$/sso-backport/sso-backport.iml" group="Skylight/sso-backport" />
+      <module fileurl="file://$PROJECT_DIR$/views/views.iml" filepath="$PROJECT_DIR$/views/views.iml" group="Skylight/views" />
     </modules>
   </component>
 </project>

--- a/views/src/main/java/drewhamilton/skylight/views/event/JavaTimeExtensions.kt
+++ b/views/src/main/java/drewhamilton/skylight/views/event/JavaTimeExtensions.kt
@@ -3,7 +3,10 @@ package drewhamilton.skylight.views.event
 import android.os.Build
 import androidx.annotation.RequiresApi
 import androidx.annotation.StringRes
+import java.time.Instant
 import java.time.OffsetTime
+import java.time.ZoneId
+import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
@@ -13,19 +16,29 @@ fun SkylightEventView.setTime(time: OffsetTime?, @StringRes fallback: Int) =
 
 @RequiresApi(Build.VERSION_CODES.O)
 fun SkylightEventView.setTime(time: OffsetTime?, formatter: DateTimeFormatter, @StringRes fallback: Int) =
-    setTime(time, formatter, context.getString(fallback))
+    setTime(time, formatter, fallback = context.getString(fallback))
+
+@RequiresApi(Build.VERSION_CODES.O)
+fun SkylightEventView.setTime(
+    time: OffsetTime?,
+    formatter: DateTimeFormatter,
+    timeZone: ZoneOffset,
+    @StringRes fallback: Int
+) = setTime(time, formatter, timeZone, context.getString(fallback))
 
 @RequiresApi(Build.VERSION_CODES.O)
 fun SkylightEventView.setTime(
     time: OffsetTime?,
     formatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT),
+    timeZone: ZoneOffset = ZoneId.systemDefault().rules.getOffset(Instant.now()),
     fallback: String = ""
 ) {
     if (time == null) {
         timeHint = fallback
         timeText = ""
     } else {
-        timeText = formatter.format(time)
+        val timeInZone = time.withOffsetSameInstant(timeZone)
+        timeText = formatter.format(timeInZone)
         timeHint = ""
     }
 }

--- a/views/src/main/java/drewhamilton/skylight/views/event/ThreeTenBpExtensions.kt
+++ b/views/src/main/java/drewhamilton/skylight/views/event/ThreeTenBpExtensions.kt
@@ -1,7 +1,10 @@
 package drewhamilton.skylight.views.event
 
 import androidx.annotation.StringRes
+import org.threeten.bp.Instant
 import org.threeten.bp.OffsetTime
+import org.threeten.bp.ZoneId
+import org.threeten.bp.ZoneOffset
 import org.threeten.bp.format.DateTimeFormatter
 import org.threeten.bp.format.FormatStyle
 
@@ -9,18 +12,27 @@ fun SkylightEventView.setTime(time: OffsetTime?, @StringRes fallback: Int) =
     setTime(time, fallback = context.getString(fallback))
 
 fun SkylightEventView.setTime(time: OffsetTime?, formatter: DateTimeFormatter, @StringRes fallback: Int) =
-    setTime(time, formatter, context.getString(fallback))
+    setTime(time, formatter, fallback = context.getString(fallback))
+
+fun SkylightEventView.setTime(
+    time: OffsetTime?,
+    formatter: DateTimeFormatter,
+    timeZone: ZoneOffset,
+    @StringRes fallback: Int
+) = setTime(time, formatter, timeZone, context.getString(fallback))
 
 fun SkylightEventView.setTime(
     time: OffsetTime?,
     formatter: DateTimeFormatter = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT),
+    timeZone: ZoneOffset = ZoneId.systemDefault().rules.getOffset(Instant.now()),
     fallback: String = ""
 ) {
     if (time == null) {
         timeHint = fallback
         timeText = ""
     } else {
-        timeText = formatter.format(time)
+        val timeInZone = time.withOffsetSameInstant(timeZone)
+        timeText = formatter.format(timeInZone)
         timeHint = ""
     }
 }

--- a/views/src/test/java/drewhamilton/skylight/views/event/AlteredTimeZoneTest.kt
+++ b/views/src/test/java/drewhamilton/skylight/views/event/AlteredTimeZoneTest.kt
@@ -1,0 +1,27 @@
+package drewhamilton.skylight.views.event
+
+import org.junit.After
+import org.junit.Before
+import java.util.TimeZone
+
+/**
+ * A base test class that alters the system default time zone to a specified time zone before each test, and restores
+ * the previous system default after each test.
+ */
+abstract class AlteredTimeZoneTest(
+    private val testSystemDefaultTimeZone: TimeZone? = TimeZone.getTimeZone("UTC")
+) {
+
+    private var systemDefaultTimeZone: TimeZone? = null
+
+    @Before
+    fun setDefaultTimeZoneToUtc() {
+        systemDefaultTimeZone = TimeZone.getDefault()
+        TimeZone.setDefault(testSystemDefaultTimeZone)
+    }
+
+    @After
+    fun restoreSystemDefaultTimeZone() {
+        TimeZone.setDefault(systemDefaultTimeZone)
+    }
+}

--- a/views/src/test/java/drewhamilton/skylight/views/event/JavaTimeExtensionsTest.kt
+++ b/views/src/test/java/drewhamilton/skylight/views/event/JavaTimeExtensionsTest.kt
@@ -15,7 +15,7 @@ import java.time.format.FormatStyle
 class JavaTimeExtensionsTest {
 
     private val dummyTime = OffsetTime.of(23, 45, 56, 789, ZoneOffset.UTC)
-    private val dummyTimeString = "Dummy date string"
+    private val dummyTimeString = "Dummy time string"
 
     private val defaultDateFormat = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
     private val defaultDummyTimeString = defaultDateFormat.format(dummyTime)
@@ -26,11 +26,10 @@ class JavaTimeExtensionsTest {
     private lateinit var mockDateTimeFormatter: DateTimeFormatter
 
     private lateinit var mockSkylightEventView: SkylightEventView
-
     private lateinit var mockContext: Context
 
     @Before
-    fun setUp() {
+    fun setUpMocks() {
         mockDateTimeFormatter = mock {
             on { format(dummyTime) } doReturn dummyTimeString
         }
@@ -44,78 +43,78 @@ class JavaTimeExtensionsTest {
     }
 
     @Test
-    fun `setTime(Date?) with non-null date sets formatted date text`() {
+    fun `setTime(OffsetTime?) with non-null date sets formatted date text`() {
         mockSkylightEventView.setTime(dummyTime)
         verifyTimeTextSet(defaultDummyTimeString)
     }
 
     @Test
-    fun `setTime(Date?) with null date sets empty text`() {
+    fun `setTime(OffsetTime?) with null date sets empty text`() {
         mockSkylightEventView.setTime(null as OffsetTime?)
         verifyTimeHintSet("")
     }
 
     @Test
-    fun `setTime(Date?, Int) with non-null date sets formatted date text`() {
+    fun `setTime(OffsetTime?, Int) with non-null date sets formatted date text`() {
         mockSkylightEventView.setTime(dummyTime, dummyFallbackStringRes)
         verify(mockSkylightEventView).context
         verifyTimeTextSet(defaultDummyTimeString)
     }
 
     @Test
-    fun `setTime(Date?, Int) with null date sets fallback text from resource`() {
+    fun `setTime(OffsetTime?, Int) with null date sets fallback text from resource`() {
         mockSkylightEventView.setTime(null as OffsetTime?, dummyFallbackStringRes)
         verify(mockSkylightEventView).context
         verifyTimeHintSet(dummyFallbackString)
     }
 
     @Test
-    fun `setTime(Date?, String) with non-null date sets formatted date text`() {
+    fun `setTime(OffsetTime?, String) with non-null date sets formatted date text`() {
         mockSkylightEventView.setTime(dummyTime, fallback = dummyFallbackString)
         verifyTimeTextSet(defaultDummyTimeString)
     }
 
     @Test
-    fun `setTime(Date?, String) with null date sets fallback text`() {
+    fun `setTime(OffsetTime?, String) with null date sets fallback text`() {
         mockSkylightEventView.setTime(null as OffsetTime?, fallback = dummyFallbackString)
         verifyTimeHintSet(dummyFallbackString)
     }
 
     @Test
-    fun `setTime(Date?, DateFormat) with non-null date sets formatted date text`() {
+    fun `setTime(OffsetTime?, DateTimeFormatter) with non-null date sets formatted date text`() {
         mockSkylightEventView.setTime(dummyTime, mockDateTimeFormatter)
         verifyTimeTextSet(dummyTimeString)
     }
 
     @Test
-    fun `setTime(Date?, DateFormat) with null date sets empty text`() {
+    fun `setTime(OffsetTime?, DateTimeFormatter) with null date sets empty text`() {
         mockSkylightEventView.setTime(null, mockDateTimeFormatter)
         verifyTimeHintSet("")
     }
 
     @Test
-    fun `setTime(Date?, DateFormat, Int) with non-null date sets formatted date text`() {
+    fun `setTime(OffsetTime?, DateTimeFormatter, Int) with non-null date sets formatted date text`() {
         mockSkylightEventView.setTime(dummyTime, mockDateTimeFormatter, dummyFallbackStringRes)
         verify(mockSkylightEventView).context
         verifyTimeTextSet(dummyTimeString)
     }
 
     @Test
-    fun `setTime(Date?, DateFormat, Int) with null date sets fallback text from resource`() {
+    fun `setTime(OffsetTime?, DateTimeFormatter, Int) with null date sets fallback text from resource`() {
         mockSkylightEventView.setTime(null, mockDateTimeFormatter, dummyFallbackStringRes)
         verify(mockSkylightEventView).context
         verifyTimeHintSet(dummyFallbackString)
     }
 
     @Test
-    fun `setTime(Date?, DateFormat, String) with non-null date sets formatted date text`() {
-        mockSkylightEventView.setTime(dummyTime, mockDateTimeFormatter, dummyFallbackString)
+    fun `setTime(OffsetTime?, DateTimeFormatter, String) with non-null date sets formatted date text`() {
+        mockSkylightEventView.setTime(dummyTime, mockDateTimeFormatter, fallback = dummyFallbackString)
         verifyTimeTextSet(dummyTimeString)
     }
 
     @Test
-    fun `setTime(Date?, DateFormat, String) with null date sets fallback text`() {
-        mockSkylightEventView.setTime(null, mockDateTimeFormatter, dummyFallbackString)
+    fun `setTime(OffsetTime?, DateTimeFormatter, String) with null date sets fallback text`() {
+        mockSkylightEventView.setTime(null, mockDateTimeFormatter, fallback = dummyFallbackString)
         verifyTimeHintSet(dummyFallbackString)
     }
 

--- a/views/src/test/java/drewhamilton/skylight/views/event/JavaTimeExtensionsTest.kt
+++ b/views/src/test/java/drewhamilton/skylight/views/event/JavaTimeExtensionsTest.kt
@@ -12,10 +12,11 @@ import java.time.ZoneOffset
 import java.time.format.DateTimeFormatter
 import java.time.format.FormatStyle
 
-class JavaTimeExtensionsTest {
+class JavaTimeExtensionsTest : AlteredTimeZoneTest() {
 
     private val dummyTime = OffsetTime.of(23, 45, 56, 789, ZoneOffset.UTC)
     private val dummyTimeString = "Dummy time string"
+    private val dummyZoneOffset = ZoneOffset.of("+02:00")
 
     private val defaultDateFormat = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
     private val defaultDummyTimeString = defaultDateFormat.format(dummyTime)
@@ -32,6 +33,7 @@ class JavaTimeExtensionsTest {
     fun setUpMocks() {
         mockDateTimeFormatter = mock {
             on { format(dummyTime) } doReturn dummyTimeString
+            on { format(dummyTime.withOffsetSameInstant(dummyZoneOffset)) } doReturn dummyTimeString
         }
 
         mockContext = mock {
@@ -102,6 +104,20 @@ class JavaTimeExtensionsTest {
     @Test
     fun `setTime(OffsetTime?, DateTimeFormatter, Int) with null date sets fallback text from resource`() {
         mockSkylightEventView.setTime(null, mockDateTimeFormatter, dummyFallbackStringRes)
+        verify(mockSkylightEventView).context
+        verifyTimeHintSet(dummyFallbackString)
+    }
+
+    @Test
+    fun `setTime(OffsetTime?, DateTimeFormatter, ZoneOffset, Int) with non-null date sets formatted date text`() {
+        mockSkylightEventView.setTime(dummyTime, mockDateTimeFormatter, dummyZoneOffset, dummyFallbackStringRes)
+        verify(mockSkylightEventView).context
+        verifyTimeTextSet(dummyTimeString)
+    }
+
+    @Test
+    fun `setTime(OffsetTime?, DateTimeFormatter, ZoneOffset, Int) with null date sets fallback text from resource`() {
+        mockSkylightEventView.setTime(null, mockDateTimeFormatter, dummyZoneOffset, dummyFallbackStringRes)
         verify(mockSkylightEventView).context
         verifyTimeHintSet(dummyFallbackString)
     }

--- a/views/src/test/java/drewhamilton/skylight/views/event/ThreeTenBpExtensionsTest.kt
+++ b/views/src/test/java/drewhamilton/skylight/views/event/ThreeTenBpExtensionsTest.kt
@@ -15,7 +15,7 @@ import org.threeten.bp.format.FormatStyle
 class ThreeTenBpExtensionsTest {
 
     private val dummyTime = OffsetTime.of(23, 45, 56, 789, ZoneOffset.UTC)
-    private val dummyTimeString = "Dummy date string"
+    private val dummyTimeString = "Dummy time string"
 
     private val defaultDateFormat = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
     private val defaultDummyTimeString = defaultDateFormat.format(dummyTime)
@@ -26,11 +26,10 @@ class ThreeTenBpExtensionsTest {
     private lateinit var mockDateTimeFormatter: DateTimeFormatter
 
     private lateinit var mockSkylightEventView: SkylightEventView
-
     private lateinit var mockContext: Context
 
     @Before
-    fun setUp() {
+    fun setUpMocks() {
         mockDateTimeFormatter = mock {
             on { format(dummyTime) } doReturn dummyTimeString
         }
@@ -44,78 +43,78 @@ class ThreeTenBpExtensionsTest {
     }
 
     @Test
-    fun `setTime(Date?) with non-null date sets formatted date text`() {
+    fun `setTime(OffsetTime?) with non-null date sets formatted date text`() {
         mockSkylightEventView.setTime(dummyTime)
         verifyTimeTextSet(defaultDummyTimeString)
     }
 
     @Test
-    fun `setTime(Date?) with null date sets empty text`() {
+    fun `setTime(OffsetTime?) with null date sets empty text`() {
         mockSkylightEventView.setTime(null as OffsetTime?)
         verifyTimeHintSet("")
     }
 
     @Test
-    fun `setTime(Date?, Int) with non-null date sets formatted date text`() {
+    fun `setTime(OffsetTime?, Int) with non-null date sets formatted date text`() {
         mockSkylightEventView.setTime(dummyTime, dummyFallbackStringRes)
         verify(mockSkylightEventView).context
         verifyTimeTextSet(defaultDummyTimeString)
     }
 
     @Test
-    fun `setTime(Date?, Int) with null date sets fallback text from resource`() {
+    fun `setTime(OffsetTime?, Int) with null date sets fallback text from resource`() {
         mockSkylightEventView.setTime(null as OffsetTime?, dummyFallbackStringRes)
         verify(mockSkylightEventView).context
         verifyTimeHintSet(dummyFallbackString)
     }
 
     @Test
-    fun `setTime(Date?, String) with non-null date sets formatted date text`() {
+    fun `setTime(OffsetTime?, String) with non-null date sets formatted date text`() {
         mockSkylightEventView.setTime(dummyTime, fallback = dummyFallbackString)
         verifyTimeTextSet(defaultDummyTimeString)
     }
 
     @Test
-    fun `setTime(Date?, String) with null date sets fallback text`() {
+    fun `setTime(OffsetTime?, String) with null date sets fallback text`() {
         mockSkylightEventView.setTime(null as OffsetTime?, fallback = dummyFallbackString)
         verifyTimeHintSet(dummyFallbackString)
     }
 
     @Test
-    fun `setTime(Date?, DateFormat) with non-null date sets formatted date text`() {
+    fun `setTime(OffsetTime?, DateTimeFormatter) with non-null date sets formatted date text`() {
         mockSkylightEventView.setTime(dummyTime, mockDateTimeFormatter)
         verifyTimeTextSet(dummyTimeString)
     }
 
     @Test
-    fun `setTime(Date?, DateFormat) with null date sets empty text`() {
+    fun `setTime(OffsetTime?, DateTimeFormatter) with null date sets empty text`() {
         mockSkylightEventView.setTime(null, mockDateTimeFormatter)
         verifyTimeHintSet("")
     }
 
     @Test
-    fun `setTime(Date?, DateFormat, Int) with non-null date sets formatted date text`() {
+    fun `setTime(OffsetTime?, DateTimeFormatter, Int) with non-null date sets formatted date text`() {
         mockSkylightEventView.setTime(dummyTime, mockDateTimeFormatter, dummyFallbackStringRes)
         verify(mockSkylightEventView).context
         verifyTimeTextSet(dummyTimeString)
     }
 
     @Test
-    fun `setTime(Date?, DateFormat, Int) with null date sets fallback text from resource`() {
+    fun `setTime(OffsetTime?, DateTimeFormatter, Int) with null date sets fallback text from resource`() {
         mockSkylightEventView.setTime(null, mockDateTimeFormatter, dummyFallbackStringRes)
         verify(mockSkylightEventView).context
         verifyTimeHintSet(dummyFallbackString)
     }
 
     @Test
-    fun `setTime(Date?, DateFormat, String) with non-null date sets formatted date text`() {
-        mockSkylightEventView.setTime(dummyTime, mockDateTimeFormatter, dummyFallbackString)
+    fun `setTime(OffsetTime?, DateTimeFormatter, String) with non-null date sets formatted date text`() {
+        mockSkylightEventView.setTime(dummyTime, mockDateTimeFormatter, fallback = dummyFallbackString)
         verifyTimeTextSet(dummyTimeString)
     }
 
     @Test
-    fun `setTime(Date?, DateFormat, String) with null date sets fallback text`() {
-        mockSkylightEventView.setTime(null, mockDateTimeFormatter, dummyFallbackString)
+    fun `setTime(OffsetTime?, DateTimeFormatter, String) with null date sets fallback text`() {
+        mockSkylightEventView.setTime(null, mockDateTimeFormatter, fallback = dummyFallbackString)
         verifyTimeHintSet(dummyFallbackString)
     }
 

--- a/views/src/test/java/drewhamilton/skylight/views/event/ThreeTenBpExtensionsTest.kt
+++ b/views/src/test/java/drewhamilton/skylight/views/event/ThreeTenBpExtensionsTest.kt
@@ -12,10 +12,11 @@ import org.threeten.bp.ZoneOffset
 import org.threeten.bp.format.DateTimeFormatter
 import org.threeten.bp.format.FormatStyle
 
-class ThreeTenBpExtensionsTest {
+class ThreeTenBpExtensionsTest : AlteredTimeZoneTest() {
 
     private val dummyTime = OffsetTime.of(23, 45, 56, 789, ZoneOffset.UTC)
     private val dummyTimeString = "Dummy time string"
+    private val dummyZoneOffset = ZoneOffset.of("+02:00")
 
     private val defaultDateFormat = DateTimeFormatter.ofLocalizedTime(FormatStyle.SHORT)
     private val defaultDummyTimeString = defaultDateFormat.format(dummyTime)
@@ -32,6 +33,7 @@ class ThreeTenBpExtensionsTest {
     fun setUpMocks() {
         mockDateTimeFormatter = mock {
             on { format(dummyTime) } doReturn dummyTimeString
+            on { format(dummyTime.withOffsetSameInstant(dummyZoneOffset)) } doReturn dummyTimeString
         }
 
         mockContext = mock {
@@ -102,6 +104,20 @@ class ThreeTenBpExtensionsTest {
     @Test
     fun `setTime(OffsetTime?, DateTimeFormatter, Int) with null date sets fallback text from resource`() {
         mockSkylightEventView.setTime(null, mockDateTimeFormatter, dummyFallbackStringRes)
+        verify(mockSkylightEventView).context
+        verifyTimeHintSet(dummyFallbackString)
+    }
+
+    @Test
+    fun `setTime(OffsetTime?, DateTimeFormatter, ZoneOffset, Int) with non-null date sets formatted date text`() {
+        mockSkylightEventView.setTime(dummyTime, mockDateTimeFormatter, dummyZoneOffset, dummyFallbackStringRes)
+        verify(mockSkylightEventView).context
+        verifyTimeTextSet(dummyTimeString)
+    }
+
+    @Test
+    fun `setTime(OffsetTime?, DateTimeFormatter, ZoneOffset, Int) with null date sets fallback text from resource`() {
+        mockSkylightEventView.setTime(null, mockDateTimeFormatter, dummyZoneOffset, dummyFallbackStringRes)
         verify(mockSkylightEventView).context
         verifyTimeHintSet(dummyFallbackString)
     }


### PR DESCRIPTION
`SkylightEventView` extension methods now have an extra parameter for the time zone that should be used to format times.