### PR TITLE
Fix `isLight` bug

### DIFF
--- a/.idea/codeStyles/Project.xml
+++ b/.idea/codeStyles/Project.xml
@@ -1,5 +1,6 @@
 <component name="ProjectCodeStyleConfiguration">
   <code_scheme name="Project" version="173">
+    <option name="RIGHT_MARGIN" value="120" />
     <AndroidXmlCodeStyleSettings>
       <option name="LAYOUT_SETTINGS">
         <value>

--- a/calculator-backport/build.gradle
+++ b/calculator-backport/build.gradle
@@ -16,6 +16,7 @@ dependencies {
   kapt "com.google.dagger:dagger-compiler:$daggerVersion"
 
   testImplementation 'junit:junit:4.12'
+  testImplementation 'org.threeten:threetenbp:1.4.0'
 }
 
 sourceCompatibility = "1.8"

--- a/calculator-backport/src/test/java/drewhamilton/skylight/backport/calculator/CalculatorSkylightTest.kt
+++ b/calculator-backport/src/test/java/drewhamilton/skylight/backport/calculator/CalculatorSkylightTest.kt
@@ -50,18 +50,17 @@ class CalculatorSkylightTest {
         assertEquals(OffsetTime.of(10, 35, 14, 739_000_000, ZoneOffset.UTC), result.sunrise)
         assertEquals(OffsetTime.of(1, 8, 52, 914_000_000, ZoneOffset.UTC), result.sunset)
         assertEquals(OffsetTime.of(1, 41, 43, 544_000_000, ZoneOffset.UTC), result.dusk)
-        assertTrue(skylight.isLight(
-            INDIANAPOLIS,
-            ZonedDateTime.of(JULY_20_2019, LocalTime.NOON, ZoneId.of("America/New_York"))
-        ))
     }
 
     @Test
     fun `Indianapolis on July 20, 2019 is light at noon`() {
-        assertTrue(skylight.isLight(
-            INDIANAPOLIS,
-            ZonedDateTime.of(JULY_20_2019, LocalTime.NOON, ZoneId.of("America/New_York"))
-        ))
+        assertTrue(
+            "Expected it to be light in Indianapolis at noon.",
+            skylight.isLight(
+                INDIANAPOLIS,
+                ZonedDateTime.of(JULY_20_2019, LocalTime.NOON, ZoneId.of("America/New_York"))
+            )
+        )
     }
     //endregion
 

--- a/calculator-backport/src/test/java/drewhamilton/skylight/backport/calculator/CalculatorSkylightTest.kt
+++ b/calculator-backport/src/test/java/drewhamilton/skylight/backport/calculator/CalculatorSkylightTest.kt
@@ -2,19 +2,23 @@ package drewhamilton.skylight.backport.calculator
 
 import drewhamilton.skylight.backport.Coordinates
 import drewhamilton.skylight.backport.SkylightDay
+import drewhamilton.skylight.backport.isLight
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import org.threeten.bp.Instant
 import org.threeten.bp.LocalDate
+import org.threeten.bp.LocalTime
 import org.threeten.bp.OffsetTime
+import org.threeten.bp.ZoneId
 import org.threeten.bp.ZoneOffset
+import org.threeten.bp.ZonedDateTime
 
 class CalculatorSkylightTest {
 
     private val skylight = CalculatorSkylight()
 
-    //region Amsterdam on January 6, 2019
+    //region Amsterdam
     @Test
     fun `Amsterdam on January 6, 2019 is typical`() {
         val result = skylight.getSkylightDay(AMSTERDAM, JANUARY_6_2019)
@@ -27,11 +31,37 @@ class CalculatorSkylightTest {
     }
     //endregion
 
-    //region Svalbard on January 6, 2019
+    //region Svalbard
     @Test
     fun `Svalbard on January 6, 2019 is never light`() {
         val result = skylight.getSkylightDay(SVALBARD, JANUARY_6_2019)
         assertEquals(SkylightDay.NeverLight(JANUARY_6_2019), result)
+    }
+    //endregion
+
+    //region Indianapolis
+    @Test
+    fun `Indianapolis on July 20, 2019 is typical`() {
+        val result = skylight.getSkylightDay(INDIANAPOLIS, JULY_20_2019)
+
+        assertTrue(result is SkylightDay.Typical)
+        result as SkylightDay.Typical
+        assertEquals(OffsetTime.of(10, 2, 24, 108_000_000, ZoneOffset.UTC), result.dawn)
+        assertEquals(OffsetTime.of(10, 35, 14, 739_000_000, ZoneOffset.UTC), result.sunrise)
+        assertEquals(OffsetTime.of(1, 8, 52, 914_000_000, ZoneOffset.UTC), result.sunset)
+        assertEquals(OffsetTime.of(1, 41, 43, 544_000_000, ZoneOffset.UTC), result.dusk)
+        assertTrue(skylight.isLight(
+            INDIANAPOLIS,
+            ZonedDateTime.of(JULY_20_2019, LocalTime.NOON, ZoneId.of("America/New_York"))
+        ))
+    }
+
+    @Test
+    fun `Indianapolis on July 20, 2019 is light at noon`() {
+        assertTrue(skylight.isLight(
+            INDIANAPOLIS,
+            ZonedDateTime.of(JULY_20_2019, LocalTime.NOON, ZoneId.of("America/New_York"))
+        ))
     }
     //endregion
 
@@ -41,7 +71,9 @@ class CalculatorSkylightTest {
     companion object {
         val AMSTERDAM = Coordinates(52.3680, 4.9036)
         val SVALBARD = Coordinates(77.8750, 20.9752)
+        val INDIANAPOLIS = Coordinates(39.7684, -86.1581)
 
         val JANUARY_6_2019: LocalDate = LocalDate.parse("2019-01-06")
+        val JULY_20_2019: LocalDate = LocalDate.parse("2019-07-20")
     }
 }

--- a/calculator/src/test/java/drewhamilton/skylight/calculator/CalculatorSkylightTest.kt
+++ b/calculator/src/test/java/drewhamilton/skylight/calculator/CalculatorSkylightTest.kt
@@ -2,19 +2,23 @@ package drewhamilton.skylight.calculator
 
 import drewhamilton.skylight.Coordinates
 import drewhamilton.skylight.SkylightDay
+import drewhamilton.skylight.isLight
 import org.junit.Assert.assertEquals
 import org.junit.Assert.assertTrue
 import org.junit.Test
 import java.time.Instant
 import java.time.LocalDate
+import java.time.LocalTime
 import java.time.OffsetTime
+import java.time.ZoneId
 import java.time.ZoneOffset
+import java.time.ZonedDateTime
 
 class CalculatorSkylightTest {
 
     private val skylight = CalculatorSkylight()
 
-    //region Amsterdam on January 6, 2019
+    //region Amsterdam
     @Test
     fun `Amsterdam on January 6, 2019 is typical`() {
         val result = skylight.getSkylightDay(AMSTERDAM, JANUARY_6_2019)
@@ -27,11 +31,36 @@ class CalculatorSkylightTest {
     }
     //endregion
 
-    //region Svalbard on January 6, 2019
+    //region Svalbard
     @Test
     fun `Svalbard on January 6, 2019 is never light`() {
         val result = skylight.getSkylightDay(SVALBARD, JANUARY_6_2019)
         assertEquals(SkylightDay.NeverLight(JANUARY_6_2019), result)
+    }
+    //endregion
+
+    //region Indianapolis
+    @Test
+    fun `Indianapolis on July 20, 2019 is typical`() {
+        val result = skylight.getSkylightDay(INDIANAPOLIS, JULY_20_2019)
+
+        assertTrue(result is SkylightDay.Typical)
+        result as SkylightDay.Typical
+        assertEquals(OffsetTime.of(10, 2, 24, 108_000_000, ZoneOffset.UTC), result.dawn)
+        assertEquals(OffsetTime.of(10, 35, 14, 739_000_000, ZoneOffset.UTC), result.sunrise)
+        assertEquals(OffsetTime.of(1, 8, 52, 914_000_000, ZoneOffset.UTC), result.sunset)
+        assertEquals(OffsetTime.of(1, 41, 43, 544_000_000, ZoneOffset.UTC), result.dusk)
+    }
+
+    @Test
+    fun `Indianapolis on July 20, 2019 is light at noon`() {
+        assertTrue(
+            "Expected it to be light in Indianapolis at noon.",
+            skylight.isLight(
+                INDIANAPOLIS,
+                ZonedDateTime.of(JULY_20_2019, LocalTime.NOON, ZoneId.of("America/New_York"))
+            )
+        )
     }
     //endregion
 
@@ -41,7 +70,9 @@ class CalculatorSkylightTest {
     companion object {
         val AMSTERDAM = Coordinates(52.3680, 4.9036)
         val SVALBARD = Coordinates(77.8750, 20.9752)
+        val INDIANAPOLIS = Coordinates(39.7684, -86.1581)
 
         val JANUARY_6_2019: LocalDate = LocalDate.parse("2019-01-06")
+        val JULY_20_2019: LocalDate = LocalDate.parse("2019-07-20")
     }
 }

--- a/skylight-backport/src/main/java/drewhamilton/skylight/backport/Skylight.kt
+++ b/skylight-backport/src/main/java/drewhamilton/skylight/backport/Skylight.kt
@@ -25,9 +25,16 @@ fun Skylight.isLight(coordinates: Coordinates, dateTime: ZonedDateTime): Boolean
         is SkylightDay.AlwaysLight -> true
         is SkylightDay.NeverLight -> false
         is SkylightDay.NeverDaytime ->
-            isLight(skylightDay.dawn, skylightDay.dusk, dateTime.toOffsetDateTime().toOffsetTime())
+            isLight(
+                skylightDay.dawn.withOffsetSameInstant(dateTime.offset),
+                skylightDay.dusk.withOffsetSameInstant(dateTime.offset),
+                dateTime.toOffsetDateTime().toOffsetTime())
         is SkylightDay.Typical ->
-            isLight(skylightDay.dawn, skylightDay.dusk, dateTime.toOffsetDateTime().toOffsetTime())
+            isLight(
+                skylightDay.dawn.withOffsetSameInstant(dateTime.offset),
+                skylightDay.dusk.withOffsetSameInstant(dateTime.offset),
+                dateTime.toOffsetDateTime().toOffsetTime()
+            )
     }
 }
 

--- a/skylight/src/main/java/drewhamilton/skylight/Skylight.kt
+++ b/skylight/src/main/java/drewhamilton/skylight/Skylight.kt
@@ -25,8 +25,16 @@ fun Skylight.isLight(coordinates: Coordinates, dateTime: ZonedDateTime): Boolean
         is SkylightDay.AlwaysDaytime -> true
         is SkylightDay.AlwaysLight -> true
         is SkylightDay.NeverLight -> false
-        is SkylightDay.NeverDaytime -> isLight(skylightDay.dawn, skylightDay.dusk, dateTime.toOffsetDateTime().toOffsetTime())
-        is SkylightDay.Typical -> isLight(skylightDay.dawn, skylightDay.dusk, dateTime.toOffsetDateTime().toOffsetTime())
+        is SkylightDay.NeverDaytime -> isLight(
+            skylightDay.dawn.withOffsetSameInstant(dateTime.offset),
+            skylightDay.dusk.withOffsetSameInstant(dateTime.offset),
+            dateTime.toOffsetDateTime().toOffsetTime()
+        )
+        is SkylightDay.Typical -> isLight(
+            skylightDay.dawn.withOffsetSameInstant(dateTime.offset),
+            skylightDay.dusk.withOffsetSameInstant(dateTime.offset),
+            dateTime.toOffsetDateTime().toOffsetTime()
+        )
     }
 }
 


### PR DESCRIPTION
`isLight` returned the wrong result when dusk crosses over past midnight UTC, which is common in UTC-0X:00 time zones. That bug is fixed here.