### PR TITLE
Redesign

### DIFF
--- a/calculator/src/main/java/drewhamilton/skylight/calculator/CalculatorSkylight.kt
+++ b/calculator/src/main/java/drewhamilton/skylight/calculator/CalculatorSkylight.kt
@@ -18,7 +18,6 @@ import javax.inject.Inject
  * depending on the exact input time. This difference has been noted to range up to almost 1 minute, but has not been
  * tested extensively. Handle the returned calculation accordingly.
  */
-@Suppress("NewApi")
 @Reusable
 class CalculatorSkylight @Inject constructor() : Skylight {
 

--- a/calculator/src/main/java/drewhamilton/skylight/calculator/CalculatorSkylight.kt
+++ b/calculator/src/main/java/drewhamilton/skylight/calculator/CalculatorSkylight.kt
@@ -16,7 +16,7 @@ import javax.inject.Inject
  *
  * Values returned are a bit "fuzzy"; that is, you can get different SkylightInfo for the same location on the same day
  * depending on the exact input time. This difference has been noted to range up to almost 1 minute, but has not been
- * tested extensively. Handle the returned calculation accordingly
+ * tested extensively. Handle the returned calculation accordingly.
  */
 @Suppress("NewApi")
 @Reusable
@@ -34,24 +34,24 @@ class CalculatorSkylight @Inject constructor() : Skylight {
             .toSkylightDay(date)
     }
 
-    private fun noonUtc() = OffsetTime.of(12, 0, 0, 0, ZoneOffset.UTC)
     private fun LocalDate.toNoonUtcEpochMillis() = atTime(noonUtc()).toInstant().toEpochMilli()
+    private fun noonUtc() = OffsetTime.of(12, 0, 0, 0, ZoneOffset.UTC)
 
     private fun EpochMilliSkylightDay.toSkylightDay(date: LocalDate) = when (this) {
-        is EpochMilliSkylightDay.Typical ->
-            SkylightDay.Typical(
-                dawn.asEpochMilliToUtcDateTime(),
-                sunrise.asEpochMilliToUtcDateTime(),
-                sunset.asEpochMilliToUtcDateTime(),
-                dusk.asEpochMilliToUtcDateTime()
-            )
-        is EpochMilliSkylightDay.AlwaysDaytime -> SkylightDay.AlwaysDaytime(date)
-        is EpochMilliSkylightDay.AlwaysLight ->
-            SkylightDay.AlwaysLight(sunrise.asEpochMilliToUtcDateTime(), sunset.asEpochMilliToUtcDateTime())
-        is EpochMilliSkylightDay.NeverDaytime ->
-            SkylightDay.NeverDaytime(dawn.asEpochMilliToUtcDateTime(), dusk.asEpochMilliToUtcDateTime())
-        is EpochMilliSkylightDay.NeverLight -> SkylightDay.NeverLight(date)
+        is EpochMilliSkylightDay.Typical -> SkylightDay.Typical {
+            this.date = date
+            this.dawn = this@toSkylightDay.dawn.asEpochMilliToUtcDateTime()
+            this.sunrise = this@toSkylightDay.sunrise.asEpochMilliToUtcDateTime()
+            this.sunset = this@toSkylightDay.sunset.asEpochMilliToUtcDateTime()
+            this.dusk = this@toSkylightDay.dusk.asEpochMilliToUtcDateTime()
+        }
+        is EpochMilliSkylightDay.AlwaysDaytime -> SkylightDay.AlwaysDaytime { this.date = date }
+        is EpochMilliSkylightDay.NeverLight -> SkylightDay.NeverLight { this.date = date }
     }
 
-    private fun Long.asEpochMilliToUtcDateTime() = ZonedDateTime.ofInstant(Instant.ofEpochMilli(this), ZoneOffset.UTC)
+    private fun Long?.asEpochMilliToUtcDateTime() =
+        if (this == null)
+            null
+        else
+            ZonedDateTime.ofInstant(Instant.ofEpochMilli(this), ZoneOffset.UTC)
 }

--- a/calculator/src/main/java/drewhamilton/skylight/calculator/EpochMilliSkylightDay.kt
+++ b/calculator/src/main/java/drewhamilton/skylight/calculator/EpochMilliSkylightDay.kt
@@ -2,44 +2,24 @@ package drewhamilton.skylight.calculator
 
 /**
  * Represents the Skylight information for a single day at a single location.
- *
- * TODO MISSING What about transition days that e.g. have a sunrise but no sunset?
  */
 internal sealed class EpochMilliSkylightDay {
 
     /**
      * Represents a normal day, where dawn and dusk represent crossing civil twilight, and sunrise and sunset represent
-     * crossing the horizon.
+     * crossing the horizon. Any of the events may be null if they don't occur on the calculated date.
      */
     data class Typical(
-        val dawn: Long,
-        val sunrise: Long,
-        val sunset: Long,
-        val dusk: Long
+        val dawn: Long?,
+        val sunrise: Long?,
+        val sunset: Long?,
+        val dusk: Long?
     ) : EpochMilliSkylightDay()
 
     /**
-     * Represents a day that is always full light, i.e. the sun never goes below the horizon.
+     * Represents a day wherein the sun never goes below the horizon.
      */
     object AlwaysDaytime : EpochMilliSkylightDay()
-
-    /**
-     * Represents a day where there is full light and twilight, but no full darkness, i.e. the sun never goes below
-     * civil twilight.
-     */
-    data class AlwaysLight(
-        val sunrise: Long,
-        val sunset: Long
-    ) : EpochMilliSkylightDay()
-
-    /**
-     * Represents a day where there is darkness and twilight, but no full light, i.e. the sun never goes above the
-     * horizon.
-     */
-    data class NeverDaytime(
-        val dawn: Long,
-        val dusk: Long
-    ) : EpochMilliSkylightDay()
 
     /**
      * Represents a day that is always darkness, i.e. the sun never goes above civil twilight.

--- a/calculator/src/test/java/drewhamilton/skylight/calculator/CalculatorSkylightTest.kt
+++ b/calculator/src/test/java/drewhamilton/skylight/calculator/CalculatorSkylightTest.kt
@@ -32,7 +32,7 @@ class CalculatorSkylightTest {
     //region Svalbard
     @Test fun `Svalbard on January 6, 2019 is never light`() {
         val result = skylight.getSkylightDay(SVALBARD, JANUARY_6_2019)
-        assertEquals(SkylightDay.NeverLight(JANUARY_6_2019), result)
+        assertEquals(SkylightDay.NeverLight { date = JANUARY_6_2019 }, result)
     }
     //endregion
 

--- a/dummy/src/main/java/drewhamilton/skylight/dummy/DummySkylight.kt
+++ b/dummy/src/main/java/drewhamilton/skylight/dummy/DummySkylight.kt
@@ -27,33 +27,20 @@ class DummySkylight @Inject constructor(
      */
     fun getSkylightDay(date: LocalDate) = dummySkylightDay.copy(date)
 
-    private fun SkylightDay.copy(date: LocalDate): SkylightDay {
-        return when (this) {
+    private fun SkylightDay.copy(newDate: LocalDate): SkylightDay {
+        return when (val original = this) {
             is SkylightDay.Typical -> {
-                val daysToAdd = dawn.toLocalDate().daysUntil(date)
-                copy(
-                    dawn = dawn.addDays(daysToAdd),
-                    sunrise = sunrise.addDays(daysToAdd),
-                    sunset = sunset.addDays(daysToAdd),
-                    dusk = dusk.addDays(daysToAdd)
-                )
+                val daysToAdd = this.date.daysUntil(newDate)
+                SkylightDay.Typical {
+                    date = newDate
+                    dawn = original.dawn?.addDays(daysToAdd)
+                    sunrise = original.sunrise?.addDays(daysToAdd)
+                    sunset = original.sunset?.addDays(daysToAdd)
+                    dusk = original.dusk?.addDays(daysToAdd)
+                }
             }
-            is SkylightDay.AlwaysDaytime -> copy(date = date)
-            is SkylightDay.AlwaysLight -> {
-                val daysToAdd = sunrise.toLocalDate().daysUntil(date)
-                copy(
-                    sunrise = sunrise.addDays(daysToAdd),
-                    sunset = sunset.addDays(daysToAdd)
-                )
-            }
-            is SkylightDay.NeverDaytime -> {
-                val daysToAdd = dawn.toLocalDate().daysUntil(date)
-                copy(
-                    dawn = dawn.addDays(daysToAdd),
-                    dusk = dusk.addDays(daysToAdd)
-                )
-            }
-            is SkylightDay.NeverLight -> copy(date = date)
+            is SkylightDay.AlwaysDaytime -> SkylightDay.AlwaysDaytime { date = newDate }
+            is SkylightDay.NeverLight -> SkylightDay.NeverLight { date = newDate }
         }
     }
 

--- a/dummy/src/test/java/drewhamilton/skylight/dummy/DummySkylightTest.kt
+++ b/dummy/src/test/java/drewhamilton/skylight/dummy/DummySkylightTest.kt
@@ -12,12 +12,13 @@ import java.time.ZonedDateTime
 
 class DummySkylightTest {
 
-    private val testSkylightDay = SkylightDay.Typical(
-        ZonedDateTime.of(1970, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC),
-        ZonedDateTime.of(1970, 1, 1, 2, 0, 0, 0, ZoneOffset.UTC),
-        ZonedDateTime.of(1970, 1, 1, 3, 0, 0, 0, ZoneOffset.UTC),
-        ZonedDateTime.of(1970, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC)
-    )
+    private val testSkylightDay = SkylightDay.Typical {
+        date = LocalDate.of(1970, 1, 1)
+        dawn = ZonedDateTime.of(1970, 1, 1, 1, 0, 0, 0, ZoneOffset.UTC)
+        sunrise = ZonedDateTime.of(1970, 1, 1, 2, 0, 0, 0, ZoneOffset.UTC)
+        sunset = ZonedDateTime.of(1970, 1, 1, 3, 0, 0, 0, ZoneOffset.UTC)
+        dusk = ZonedDateTime.of(1970, 1, 1, 4, 0, 0, 0, ZoneOffset.UTC)
+    }
 
     private lateinit var dummySkylight: DummySkylight
 
@@ -31,28 +32,28 @@ class DummySkylightTest {
         val result1 = dummySkylight.getSkylightDay(Coordinates(0.0, 0.0), LocalDate.MIN)
         assertTrue(result1 is SkylightDay.Typical)
         result1 as SkylightDay.Typical
-        assertEquals(LocalDate.MIN, result1.dawn.toLocalDate())
-        assertEquals(testSkylightDay.dawn.toLocalTime(), result1.dawn.toLocalTime())
-        assertEquals(testSkylightDay.dawn.offset, result1.dawn.offset)
-        assertEquals(testSkylightDay.sunrise.toLocalTime(), result1.sunrise.toLocalTime())
-        assertEquals(testSkylightDay.sunrise.offset, result1.sunrise.offset)
-        assertEquals(testSkylightDay.sunset.toLocalTime(), result1.sunset.toLocalTime())
-        assertEquals(testSkylightDay.sunset.offset, result1.sunset.offset)
-        assertEquals(testSkylightDay.dusk.toLocalTime(), result1.dusk.toLocalTime())
-        assertEquals(testSkylightDay.dusk.offset, result1.dusk.offset)
+        assertEquals(LocalDate.MIN, result1.dawn?.toLocalDate())
+        assertEquals(testSkylightDay.dawn!!.toLocalTime(), result1.dawn?.toLocalTime())
+        assertEquals(testSkylightDay.dawn!!.offset, result1.dawn?.offset)
+        assertEquals(testSkylightDay.sunrise!!.toLocalTime(), result1.sunrise?.toLocalTime())
+        assertEquals(testSkylightDay.sunrise!!.offset, result1.sunrise?.offset)
+        assertEquals(testSkylightDay.sunset!!.toLocalTime(), result1.sunset?.toLocalTime())
+        assertEquals(testSkylightDay.sunset!!.offset, result1.sunset?.offset)
+        assertEquals(testSkylightDay.dusk!!.toLocalTime(), result1.dusk?.toLocalTime())
+        assertEquals(testSkylightDay.dusk!!.offset, result1.dusk?.offset)
 
         val result2 = dummySkylight.getSkylightDay(Coordinates(90.0, 180.0), LocalDate.MAX)
         assertTrue(result2 is SkylightDay.Typical)
         result2 as SkylightDay.Typical
-        assertEquals(LocalDate.MAX, result2.dawn.toLocalDate())
-        assertEquals(testSkylightDay.dawn.toLocalTime(), result2.dawn.toLocalTime())
-        assertEquals(testSkylightDay.dawn.offset, result2.dawn.offset)
-        assertEquals(testSkylightDay.sunrise.toLocalTime(), result2.sunrise.toLocalTime())
-        assertEquals(testSkylightDay.sunrise.offset, result2.sunrise.offset)
-        assertEquals(testSkylightDay.sunset.toLocalTime(), result2.sunset.toLocalTime())
-        assertEquals(testSkylightDay.sunset.offset, result2.sunset.offset)
-        assertEquals(testSkylightDay.dusk.toLocalTime(), result2.dusk.toLocalTime())
-        assertEquals(testSkylightDay.dusk.offset, result2.dusk.offset)
+        assertEquals(LocalDate.MAX, result2.dawn?.toLocalDate())
+        assertEquals(testSkylightDay.dawn!!.toLocalTime(), result2.dawn?.toLocalTime())
+        assertEquals(testSkylightDay.dawn!!.offset, result2.dawn?.offset)
+        assertEquals(testSkylightDay.sunrise!!.toLocalTime(), result2.sunrise?.toLocalTime())
+        assertEquals(testSkylightDay.sunrise!!.offset, result2.sunrise?.offset)
+        assertEquals(testSkylightDay.sunset!!.toLocalTime(), result2.sunset?.toLocalTime())
+        assertEquals(testSkylightDay.sunset!!.offset, result2.sunset?.offset)
+        assertEquals(testSkylightDay.dusk!!.toLocalTime(), result2.dusk?.toLocalTime())
+        assertEquals(testSkylightDay.dusk!!.offset, result2.dusk?.offset)
     }
 
     @Test
@@ -61,14 +62,14 @@ class DummySkylightTest {
         val result = dummySkylight.getSkylightDay(testDate)
         assertTrue(result is SkylightDay.Typical)
         result as SkylightDay.Typical
-        assertEquals(testDate, result.dawn.toLocalDate())
-        assertEquals(testSkylightDay.dawn.toLocalTime(), result.dawn.toLocalTime())
-        assertEquals(testSkylightDay.dawn.offset, result.dawn.offset)
-        assertEquals(testSkylightDay.sunrise.toLocalTime(), result.sunrise.toLocalTime())
-        assertEquals(testSkylightDay.sunrise.offset, result.sunrise.offset)
-        assertEquals(testSkylightDay.sunset.toLocalTime(), result.sunset.toLocalTime())
-        assertEquals(testSkylightDay.sunset.offset, result.sunset.offset)
-        assertEquals(testSkylightDay.dusk.toLocalTime(), result.dusk.toLocalTime())
-        assertEquals(testSkylightDay.dusk.offset, result.dusk.offset)
+        assertEquals(testDate, result.dawn?.toLocalDate())
+        assertEquals(testSkylightDay.dawn!!.toLocalTime(), result.dawn?.toLocalTime())
+        assertEquals(testSkylightDay.dawn!!.offset, result.dawn?.offset)
+        assertEquals(testSkylightDay.sunrise!!.toLocalTime(), result.sunrise?.toLocalTime())
+        assertEquals(testSkylightDay.sunrise!!.offset, result.sunrise?.offset)
+        assertEquals(testSkylightDay.sunset!!.toLocalTime(), result.sunset?.toLocalTime())
+        assertEquals(testSkylightDay.sunset!!.offset, result.sunset?.offset)
+        assertEquals(testSkylightDay.dusk!!.toLocalTime(), result.dusk?.toLocalTime())
+        assertEquals(testSkylightDay.dusk!!.offset, result.dusk?.offset)
     }
 }

--- a/dummy/src/test/java/drewhamilton/skylight/dummy/dagger/DummySkylightComponentTest.kt
+++ b/dummy/src/test/java/drewhamilton/skylight/dummy/dagger/DummySkylightComponentTest.kt
@@ -8,7 +8,7 @@ import java.time.LocalDate
 class DummySkylightComponentTest {
 
     private val testDate = LocalDate.ofEpochDay(4)
-    private val testSkylightDay = SkylightDay.NeverLight(testDate)
+    private val testSkylightDay = SkylightDay.NeverLight { date = testDate }
 
     @Test
     fun `create returns DummySkylightComponent with dummySkylightDay`() {

--- a/rx/src/test/java/drewhamilton/skylight/rx/TestHelpers.kt
+++ b/rx/src/test/java/drewhamilton/skylight/rx/TestHelpers.kt
@@ -7,11 +7,12 @@ import java.time.ZonedDateTime
 
 private const val timeDifferenceSeconds = 5L
 
-internal fun dummyTypical(date: LocalDate, dawn: OffsetTime) = SkylightDay.Typical(
-    zonedDateTimeOf(date, dawn),
-    zonedDateTimeOf(date, dawn.plusSeconds(timeDifferenceSeconds)),
-    zonedDateTimeOf(date, dawn.plusSeconds(2 * timeDifferenceSeconds)),
-    zonedDateTimeOf(date, dawn.plusSeconds(3 * timeDifferenceSeconds))
-)
+internal fun dummyTypical(date: LocalDate, dawn: OffsetTime) = SkylightDay.Typical {
+    this.date = date
+    this.dawn = zonedDateTimeOf(date, dawn)
+    this.sunrise = zonedDateTimeOf(date, dawn.plusSeconds(timeDifferenceSeconds))
+    this.sunset = zonedDateTimeOf(date, dawn.plusSeconds(2 * timeDifferenceSeconds))
+    this.dusk = zonedDateTimeOf(date, dawn.plusSeconds(3 * timeDifferenceSeconds))
+}
 
 private fun zonedDateTimeOf(date: LocalDate, time: OffsetTime) = ZonedDateTime.of(date, time.toLocalTime(), time.offset)

--- a/skylight/src/main/java/drewhamilton/skylight/Skylight.kt
+++ b/skylight/src/main/java/drewhamilton/skylight/Skylight.kt
@@ -21,11 +21,9 @@ interface Skylight {
 @Suppress("NewApi")
 fun Skylight.isLight(coordinates: Coordinates, dateTime: ZonedDateTime) =
     when (val skylightDay = getSkylightDay(coordinates, dateTime.toLocalDate())) {
-        is SkylightDay.AlwaysDaytime,
-        is SkylightDay.AlwaysLight -> true
+        is SkylightDay.AlwaysDaytime -> true
         is SkylightDay.NeverLight -> false
-        is SkylightDay.NeverDaytime -> isLight(skylightDay.dawn, skylightDay.dusk, dateTime)
-        is SkylightDay.Typical -> isLight(skylightDay.dawn, skylightDay.dusk, dateTime)
+        is SkylightDay.Typical -> skylightDay.isLight(dateTime)
     }
 
 /**
@@ -34,5 +32,5 @@ fun Skylight.isLight(coordinates: Coordinates, dateTime: ZonedDateTime) =
  */
 fun Skylight.isDark(coordinates: Coordinates, dateTime: ZonedDateTime) = !isLight(coordinates, dateTime)
 
-private fun isLight(dawn: ZonedDateTime, dusk: ZonedDateTime, time: ZonedDateTime) =
-    dawn.isBefore(time) && dusk.isAfter(time)
+private fun SkylightDay.Typical.isLight(time: ZonedDateTime) = dawn == null ||
+        (dawn.isBefore(time) && (dusk == null || dusk.isAfter(time)))

--- a/skylight/src/main/java/drewhamilton/skylight/Skylight.kt
+++ b/skylight/src/main/java/drewhamilton/skylight/Skylight.kt
@@ -18,7 +18,6 @@ interface Skylight {
  * Determine whether it is light outside at the given [coordinates] at the given [dateTime], where "light" means after
  * dawn and before dusk on the given date.
  */
-@Suppress("NewApi")
 fun Skylight.isLight(coordinates: Coordinates, dateTime: ZonedDateTime) =
     when (val skylightDay = getSkylightDay(coordinates, dateTime.toLocalDate())) {
         is SkylightDay.AlwaysDaytime -> true

--- a/skylight/src/main/java/drewhamilton/skylight/SkylightDay.kt
+++ b/skylight/src/main/java/drewhamilton/skylight/SkylightDay.kt
@@ -2,55 +2,143 @@ package drewhamilton.skylight
 
 import java.time.LocalDate
 import java.time.ZonedDateTime
+import java.util.Objects
 
 /**
  * Represents the Skylight information for a single day at a single location.
  */
-// TODO MISSING: What about transition days that e.g. have a sunrise but no sunset?
 sealed class SkylightDay {
+
+    /**
+     * The date represented by the [SkylightDay].
+     */
+    abstract val date: LocalDate
 
     /**
      * Represents a normal day, where dawn and dusk represent crossing civil twilight, and sunrise and sunset represent
      * crossing the horizon.
+     *
+     * A null value for [dawn], [sunrise], [sunset], or [dusk] indicate that that event does not occur on that [date].
+     * Different null values have different implications. For example, if only [dawn] and [dusk] are null, the day is
+     * always light, but the sun does cross the horizon. If only [sunrise] and [sunset] are null, the sun never crosses
+     * above the horizon, but the day does change from dark to light and back. Rarely, 1 or 3 of the values may be null,
+     * if the date is a transition day from one sunrise/sunset pattern to another.
+     *
+     * It should never be the case that all 4 event values are null. In those cases where a day does not have any of
+     * these events, either [AlwaysDaytime] or [NeverLight] should be used.
      */
-    data class Typical(
-        val dawn: ZonedDateTime,
-        val sunrise: ZonedDateTime,
-        val sunset: ZonedDateTime,
-        val dusk: ZonedDateTime
-    ) : SkylightDay()
+    class Typical private constructor(
+        override val date: LocalDate,
+        val dawn: ZonedDateTime?,
+        val sunrise: ZonedDateTime?,
+        val sunset: ZonedDateTime?,
+        val dusk: ZonedDateTime?
+    ) : SkylightDay() {
+        override fun toString() =
+            "SkylightDay.Typical(date=$date, dawn=$dawn, sunrise=$sunrise, sunset=$sunset, dusk=$dusk)"
+        override fun equals(other: Any?) = other is Typical &&
+                date == other.date &&
+                dawn == other.dawn &&
+                sunrise == other.sunrise &&
+                sunset == other.sunset &&
+                dusk == other.dusk
+        override fun hashCode() = Objects.hash(date, dawn, sunrise, sunset, dusk)
+
+        class Builder {
+            @set:JvmSynthetic
+            var date: LocalDate? = null
+
+            @set:JvmSynthetic
+            var dawn: ZonedDateTime? = null
+
+            @set:JvmSynthetic
+            var sunrise: ZonedDateTime? = null
+
+            @set:JvmSynthetic
+            var sunset: ZonedDateTime? = null
+
+            @set:JvmSynthetic
+            var dusk: ZonedDateTime? = null
+
+            fun setDate(date: LocalDate?) = apply { this.date = date }
+            fun setDawn(dawn: ZonedDateTime?) = apply { this.dawn = dawn }
+            fun setSunrise(sunrise: ZonedDateTime?) = apply { this.sunrise = sunrise }
+            fun setSunset(sunset: ZonedDateTime?) = apply { this.sunset = sunset }
+            fun setDusk(dusk: ZonedDateTime?) = apply { this.dusk = dusk }
+
+            fun build(): Typical {
+                val date = checkNotNull(date) { "All SkylightDays must have a date" }
+                check(!(dawn == null && sunrise == null && sunset == null && dusk == null)) {
+                    "At least one of dawn, sunrise, sunset, and dusk must be non-null"
+                }
+                return Typical(date, dawn, sunrise, sunset, dusk)
+            }
+        }
+    }
 
     /**
-     * Represents a day that is always full light, i.e. the sun never goes below the horizon.
+     * Represents a day wherein the sun never goes below the horizon.
      */
-    data class AlwaysDaytime(
-        val date: LocalDate
-    ) : SkylightDay()
+    class AlwaysDaytime private constructor(
+        override val date: LocalDate
+    ) : SkylightDay() {
+        override fun toString() = "SkylightDay.AlwaysDaytime(date=$date)"
+        override fun equals(other: Any?) = other is AlwaysDaytime && date == other.date
+        // Constant "1" ensures hash code is unique from NeverLight:
+        override fun hashCode() = Objects.hash(1, date)
+
+        class Builder {
+            @set:JvmSynthetic
+            var date: LocalDate? = null
+
+            fun setDate(date: LocalDate?) = apply { this.date = date }
+
+            fun build(): AlwaysDaytime {
+                val date = checkNotNull(date) { "All SkylightDays must have a date" }
+                return AlwaysDaytime(date)
+            }
+        }
+    }
 
     /**
-     * Represents a day where there is full light and twilight, but no full darkness, i.e. the sun never goes below
-     * civil twilight.
+     * Represents a day that is always dark, i.e. the sun never goes above civil twilight.
      */
-    data class AlwaysLight(
-        val sunrise: ZonedDateTime,
-        val sunset: ZonedDateTime
-    ) : SkylightDay()
+    class NeverLight private constructor(
+        override val date: LocalDate
+    ) : SkylightDay() {
+        override fun toString() = "SkylightDay.NeverLight(date=$date)"
+        override fun equals(other: Any?) = other is NeverLight && date == other.date
+        // Constant "2" ensures hash code is unique from AlwaysDaytime:
+        override fun hashCode() = Objects.hash(2, date)
 
-    /**
-     * Represents a day where there is darkness and twilight, but no full light, i.e. the sun never goes above the
-     * horizon.
-     */
-    data class NeverDaytime(
-        val dawn: ZonedDateTime,
-        val dusk: ZonedDateTime
-    ) : SkylightDay()
+        class Builder {
+            @set:JvmSynthetic
+            var date: LocalDate? = null
 
-    /**
-     * Represents a day that is always darkness, i.e. the sun never goes above civil twilight.
-     */
-    data class NeverLight(
-        val date: LocalDate
-    ) : SkylightDay()
+            fun setDate(date: LocalDate?) = apply { this.date = date }
 
+            fun build(): NeverLight {
+                val date = checkNotNull(date) { "All SkylightDays must have a date" }
+                return NeverLight(date)
+            }
+        }
+    }
+
+    companion object {
+        @Suppress("FunctionName") // Initializer DSL pattern
+        fun Typical(initializer: Typical.Builder.() -> Unit): Typical = Typical.Builder()
+            .apply(initializer)
+            .build()
+
+        @Suppress("FunctionName") // Initializer DSL pattern
+        fun AlwaysDaytime(initializer: AlwaysDaytime.Builder.() -> Unit): AlwaysDaytime = AlwaysDaytime.Builder()
+            .apply(initializer)
+            .build()
+
+        @Suppress("FunctionName") // Initializer DSL pattern
+        fun NeverLight(initializer: NeverLight.Builder.() -> Unit): NeverLight = NeverLight.Builder()
+            .apply(initializer)
+            .build()
+    }
 }
 

--- a/skylight/src/main/java/drewhamilton/skylight/SkylightForDate.kt
+++ b/skylight/src/main/java/drewhamilton/skylight/SkylightForDate.kt
@@ -8,7 +8,6 @@ import javax.inject.Inject
  */
 // TODO: Determine if @Inject internal constructor works with Dagger in another module
 // TODO: Investigate assisted injection
-@Suppress("NewApi")
 class SkylightForDate @Inject internal constructor(
     private val skylight: Skylight,
     val date: LocalDate

--- a/skylight/src/test/java/drewhamilton/skylight/SkylightDayJavaTest.java
+++ b/skylight/src/test/java/drewhamilton/skylight/SkylightDayJavaTest.java
@@ -1,0 +1,164 @@
+package drewhamilton.skylight;
+
+import org.junit.Test;
+
+import java.time.LocalDate;
+import java.time.ZonedDateTime;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+public class SkylightDayJavaTest {
+
+    //region SkylightDay.Typical
+    @Test(expected = IllegalStateException.class)
+    public void typicalInitializer_withoutDate_throwsException() {
+        new SkylightDay.Typical.Builder()
+                .setDawn(ZonedDateTime.parse("2020-01-13T07:00:00+02:00"))
+                .setSunrise(ZonedDateTime.parse("2020-01-13T09:00:00+02:00"))
+                .setSunset(ZonedDateTime.parse("2020-01-13T18:00:00+02:00"))
+                .setDusk(ZonedDateTime.parse("2020-01-13T20:00:00+02:00"))
+                .build();
+    }
+
+    @Test(expected = IllegalStateException.class)
+    public void typicalInitializer_withoutAnyEvents_throwsException() {
+        new SkylightDay.Typical.Builder()
+                .setDate(LocalDate.parse("2020-01-13"))
+                .build();
+    }
+
+    @Test
+    public void typical_withSameValues_areEquals() {
+        SkylightDay.Typical day1 = new SkylightDay.Typical.Builder()
+                .setDate(LocalDate.parse("2020-01-13"))
+                .setDawn(ZonedDateTime.parse("2020-01-13T07:00:00+02:00"))
+                .setDusk(ZonedDateTime.parse("2020-01-13T20:00:00+02:00"))
+                .build();
+        SkylightDay.Typical day2 = new SkylightDay.Typical.Builder()
+                .setDate(LocalDate.parse("2020-01-13"))
+                .setDawn(ZonedDateTime.parse("2020-01-13T07:00:00+02:00"))
+                .setDusk(ZonedDateTime.parse("2020-01-13T20:00:00+02:00"))
+                .build();
+        assertEquals(day1, day2);
+        assertEquals(day1.hashCode(), day2.hashCode());
+    }
+
+    @Test
+    public void typical_withDifferentValues_areNotEquals() {
+        SkylightDay.Typical day1 = new SkylightDay.Typical.Builder()
+                .setDate(LocalDate.parse("2020-01-13"))
+                .setSunrise(ZonedDateTime.parse("2020-01-13T09:00:00+02:00"))
+                .setSunset(ZonedDateTime.parse("2020-01-13T18:00:00+02:00"))
+                .build();
+        SkylightDay.Typical day2 = new SkylightDay.Typical.Builder()
+                .setDate(LocalDate.parse("2020-01-13"))
+                .setDawn(ZonedDateTime.parse("2020-01-13T07:00:00+02:00"))
+                .setDusk(ZonedDateTime.parse("2020-01-13T20:00:00+02:00"))
+                .build();
+        assertNotEquals(day1, day2);
+        assertNotEquals(day1.hashCode(), day2.hashCode());
+    }
+
+    @Test
+    public void typicalBuilder_assignsExpectedValues() {
+        LocalDate date = LocalDate.parse("2020-01-13");
+        ZonedDateTime dawn = ZonedDateTime.parse("2020-01-13T07:00:00+02:00");
+        ZonedDateTime sunrise = ZonedDateTime.parse("2020-01-13T09:00:00+02:00");
+        ZonedDateTime sunset = ZonedDateTime.parse("2020-01-13T18:00:00+02:00");
+        ZonedDateTime dusk = ZonedDateTime.parse("2020-01-13T20:00:00+02:00");
+        SkylightDay.Typical day = new SkylightDay.Typical.Builder()
+                .setDate(date)
+                .setDawn(dawn)
+                .setSunrise(sunrise)
+                .setSunset(sunset)
+                .setDusk(dusk)
+                .build();
+        assertEquals(date, day.getDate());
+        assertEquals(dawn, day.getDawn());
+        assertEquals(sunrise, day.getSunrise());
+        assertEquals(sunset, day.getSunset());
+        assertEquals(dusk, day.getDusk());
+    }
+    //endregion
+
+    //region SkylightDay.AlwaysDaytime
+    @Test(expected = IllegalStateException.class)
+    public void alwaysDaytimeInitializer_withoutDate_throwsException() {
+        new SkylightDay.AlwaysDaytime.Builder().build();
+    }
+
+    @Test
+    public void alwaysDaytime_withSameValues_areEquals() {
+        SkylightDay.AlwaysDaytime day1 = new SkylightDay.AlwaysDaytime.Builder()
+                .setDate(LocalDate.parse("2020-01-13"))
+                .build();
+        SkylightDay.AlwaysDaytime day2 = new SkylightDay.AlwaysDaytime.Builder()
+                .setDate(LocalDate.parse("2020-01-13"))
+                .build();
+        assertEquals(day1, day2);
+        assertEquals(day1.hashCode(), day2.hashCode());
+    }
+
+    @Test
+    public void alwaysDaytime_withDifferentValues_areNotEquals() {
+        SkylightDay.AlwaysDaytime day1 = new SkylightDay.AlwaysDaytime.Builder()
+                .setDate(LocalDate.parse("2020-01-13"))
+                .build();
+        SkylightDay.AlwaysDaytime day2 = new SkylightDay.AlwaysDaytime.Builder()
+                .setDate(LocalDate.parse("2020-01-14"))
+                .build();
+        assertNotEquals(day1, day2);
+        assertNotEquals(day1.hashCode(), day2.hashCode());
+    }
+
+    @Test
+    public void alwaysDaytimeBuilder_assignsExpectedValues() {
+        LocalDate date = LocalDate.parse("2020-01-13");
+        SkylightDay.AlwaysDaytime day = new SkylightDay.AlwaysDaytime.Builder()
+                .setDate(date)
+                .build();
+        assertEquals(date, day.getDate());
+    }
+    //endregion
+
+    //region SkylightDay.NeverLight
+    @Test(expected = IllegalStateException.class)
+    public void neverLightInitializer_withoutDate_throwsException() {
+        new SkylightDay.NeverLight.Builder().build();
+    }
+
+    @Test
+    public void neverLight_withSameValues_areEquals() {
+        SkylightDay.NeverLight day1 = new SkylightDay.NeverLight.Builder()
+                .setDate(LocalDate.parse("2020-01-13"))
+                .build();
+        SkylightDay.NeverLight day2 = new SkylightDay.NeverLight.Builder()
+                .setDate(LocalDate.parse("2020-01-13"))
+                .build();
+        assertEquals(day1, day2);
+        assertEquals(day1.hashCode(), day2.hashCode());
+    }
+
+    @Test
+    public void neverLight_withDifferentValues_areNotEquals() {
+        SkylightDay.NeverLight day1 = new SkylightDay.NeverLight.Builder()
+                .setDate(LocalDate.parse("2020-01-13"))
+                .build();
+        SkylightDay.NeverLight day2 = new SkylightDay.NeverLight.Builder()
+                .setDate(LocalDate.parse("2020-01-14"))
+                .build();
+        assertNotEquals(day1, day2);
+        assertNotEquals(day1.hashCode(), day2.hashCode());
+    }
+
+    @Test
+    public void neverLightBuilder_assignsExpectedValues() {
+        LocalDate date = LocalDate.parse("2020-01-13");
+        SkylightDay.NeverLight day = new SkylightDay.NeverLight.Builder()
+                .setDate(date)
+                .build();
+        assertEquals(date, day.getDate());
+    }
+    //endregion
+}

--- a/skylight/src/test/java/drewhamilton/skylight/SkylightDayTest.kt
+++ b/skylight/src/test/java/drewhamilton/skylight/SkylightDayTest.kt
@@ -1,0 +1,194 @@
+package drewhamilton.skylight
+
+import org.junit.Assert.assertEquals
+import org.junit.Assert.assertNotEquals
+import org.junit.Test
+import java.time.LocalDate
+import java.time.ZonedDateTime
+
+class SkylightDayTest {
+
+    //region SkylightDay.Typical
+    @Test(expected = IllegalStateException::class)
+    fun `Typical initializer without date throws exception`() {
+        SkylightDay.Typical {
+            dawn = ZonedDateTime.parse("2020-01-13T07:00:00+02:00")
+            sunrise = ZonedDateTime.parse("2020-01-13T09:00:00+02:00")
+            sunset = ZonedDateTime.parse("2020-01-13T18:00:00+02:00")
+            dusk = ZonedDateTime.parse("2020-01-13T20:00:00+02:00")
+        }
+    }
+
+    @Test(expected = IllegalStateException::class)
+    fun `Typical initializer without any events throws exception`() {
+        SkylightDay.Typical {
+            date = LocalDate.parse("2020-01-13")
+        }
+    }
+
+    @Test fun `Typical with same values are equals`() {
+        val day1 = SkylightDay.Typical {
+            date = LocalDate.parse("2020-01-13")
+            dawn = ZonedDateTime.parse("2020-01-13T07:00:00+02:00")
+            dusk = ZonedDateTime.parse("2020-01-13T20:00:00+02:00")
+        }
+        val day2 = SkylightDay.Typical {
+            date = LocalDate.parse("2020-01-13")
+            dawn = ZonedDateTime.parse("2020-01-13T07:00:00+02:00")
+            dusk = ZonedDateTime.parse("2020-01-13T20:00:00+02:00")
+        }
+        assertEquals(day1, day2)
+        assertEquals(day1.hashCode(), day2.hashCode())
+    }
+
+    @Test fun `Typical with different values are not equals`() {
+        val day1 = SkylightDay.Typical {
+            date = LocalDate.parse("2020-01-13")
+            sunrise = ZonedDateTime.parse("2020-01-13T07:00:00+02:00")
+            sunset = ZonedDateTime.parse("2020-01-13T20:00:00+02:00")
+        }
+        val day2 = SkylightDay.Typical {
+            date = LocalDate.parse("2020-01-13")
+            dawn = ZonedDateTime.parse("2020-01-13T07:00:00+02:00")
+            dusk = ZonedDateTime.parse("2020-01-13T20:00:00+02:00")
+        }
+        assertNotEquals(day1, day2)
+        assertNotEquals(day1.hashCode(), day2.hashCode())
+    }
+
+    @Test fun `Typical DSL assigns expected values`() {
+        val date = LocalDate.parse("2020-01-13")
+        val dawn = ZonedDateTime.parse("2020-01-13T07:00:00+02:00")
+        val sunrise = ZonedDateTime.parse("2020-01-13T09:00:00+02:00")
+        val sunset = ZonedDateTime.parse("2020-01-13T18:00:00+02:00")
+        val dusk = ZonedDateTime.parse("2020-01-13T20:00:00+02:00")
+        val day = SkylightDay.Typical {
+            this.date = date
+            this.dawn = dawn
+            this.sunrise = sunrise
+            this.sunset = sunset
+            this.dusk = dusk
+        }
+        assertEquals(date, day.date)
+        assertEquals(dawn, day.dawn)
+        assertEquals(sunrise, day.sunrise)
+        assertEquals(sunset, day.sunset)
+        assertEquals(dusk, day.dusk)
+    }
+
+    @Test fun `Typical toString returns value string`() {
+        val day = SkylightDay.Typical {
+            date = LocalDate.parse("2020-01-13")
+            dawn = ZonedDateTime.parse("2020-01-13T07:00:00+02:00")
+            sunrise = ZonedDateTime.parse("2020-01-13T09:00:00+02:00")
+            sunset = ZonedDateTime.parse("2020-01-13T18:00:00+02:00")
+            dusk = ZonedDateTime.parse("2020-01-13T20:00:00+02:00")
+        }
+        val expected = "SkylightDay.Typical(" +
+                "date=${day.date}, dawn=${day.dawn}, sunrise=${day.sunrise}, sunset=${day.sunset}, dusk=${day.dusk}" +
+                ")"
+        assertEquals(expected, day.toString())
+    }
+    //endregion
+
+    //region SkylightDay.AlwaysDaytime
+    @Test(expected = IllegalStateException::class)
+    fun `AlwaysDaytime initializer without date throws exception`() {
+        SkylightDay.AlwaysDaytime {}
+    }
+
+    @Test fun `AlwaysDaytime with same values are equals`() {
+        val day1 = SkylightDay.AlwaysDaytime {
+            date = LocalDate.parse("2020-01-13")
+        }
+        val day2 = SkylightDay.AlwaysDaytime {
+            date = LocalDate.parse("2020-01-13")
+        }
+        assertEquals(day1, day2)
+        assertEquals(day1.hashCode(), day2.hashCode())
+    }
+
+    @Test fun `AlwaysDaytime with different values are not equals`() {
+        val day1 = SkylightDay.AlwaysDaytime {
+            date = LocalDate.parse("2020-01-13")
+        }
+        val day2 = SkylightDay.AlwaysDaytime {
+            date = LocalDate.parse("2020-01-14")
+        }
+        assertNotEquals(day1, day2)
+        assertNotEquals(day1.hashCode(), day2.hashCode())
+    }
+
+    @Test fun `AlwaysDaytime DSL assigns expected values`() {
+        val date = LocalDate.parse("2020-01-13")
+        val day = SkylightDay.AlwaysDaytime {
+            this.date = date
+        }
+        assertEquals(date, day.date)
+    }
+
+    @Test fun `AlwaysDaytime toString returns value string`() {
+        val day = SkylightDay.AlwaysDaytime {
+            date = LocalDate.parse("2020-01-13")
+        }
+        val expected = "SkylightDay.AlwaysDaytime(date=${day.date})"
+        assertEquals(expected, day.toString())
+    }
+    //endregion
+
+    //region SkylightDay.NeverLight
+    @Test(expected = IllegalStateException::class)
+    fun `NeverLight initializer without date throws exception`() {
+        SkylightDay.NeverLight {}
+    }
+
+    @Test fun `NeverLight with same values are equals`() {
+        val day1 = SkylightDay.NeverLight {
+            date = LocalDate.parse("2020-01-13")
+        }
+        val day2 = SkylightDay.NeverLight {
+            date = LocalDate.parse("2020-01-13")
+        }
+        assertEquals(day1, day2)
+        assertEquals(day1.hashCode(), day2.hashCode())
+    }
+
+    @Test fun `NeverLight with different values are not equals`() {
+        val day1 = SkylightDay.NeverLight {
+            date = LocalDate.parse("2020-01-13")
+        }
+        val day2 = SkylightDay.NeverLight {
+            date = LocalDate.parse("2020-01-14")
+        }
+        assertNotEquals(day1, day2)
+        assertNotEquals(day1.hashCode(), day2.hashCode())
+    }
+
+    @Test fun `NeverLight DSL assigns expected values`() {
+        val date = LocalDate.parse("2020-01-13")
+        val day = SkylightDay.NeverLight {
+            this.date = date
+        }
+        assertEquals(date, day.date)
+    }
+
+    @Test fun `NeverLight toString returns value string`() {
+        val day = SkylightDay.NeverLight {
+            date = LocalDate.parse("2020-01-13")
+        }
+        val expected = "SkylightDay.NeverLight(date=${day.date})"
+        assertEquals(expected, day.toString())
+    }
+    //endregion
+
+    @Test fun `AlwaysDaytime and NeverLight are not equals`() {
+        val day1: SkylightDay = SkylightDay.AlwaysDaytime {
+            date = LocalDate.parse("2020-01-13")
+        }
+        val day2: SkylightDay = SkylightDay.NeverLight {
+            date = LocalDate.parse("2020-01-13")
+        }
+        assertNotEquals(day1, day2)
+        assertNotEquals(day1.hashCode(), day2.hashCode())
+    }
+}

--- a/skylight/src/test/java/drewhamilton/skylight/SkylightForCoordinatesTest.kt
+++ b/skylight/src/test/java/drewhamilton/skylight/SkylightForCoordinatesTest.kt
@@ -64,11 +64,15 @@ class SkylightForCoordinatesTest {
     }
 
     private fun KClass<out SkylightDay>.instantiate(date: LocalDate) = when (this) {
-        SkylightDay.Typical::class -> SkylightDay.Typical(testDateTime, testDateTime, testDateTime, testDateTime)
-        SkylightDay.AlwaysDaytime::class -> SkylightDay.AlwaysDaytime(date)
-        SkylightDay.AlwaysLight::class -> SkylightDay.AlwaysLight(testDateTime, testDateTime)
-        SkylightDay.NeverDaytime::class -> SkylightDay.NeverDaytime(testDateTime, testDateTime)
-        SkylightDay.NeverLight::class -> SkylightDay.NeverLight(date)
+        SkylightDay.Typical::class -> SkylightDay.Typical {
+            this.date = date
+            this.dawn = testDateTime
+            this.sunrise = testDateTime
+            this.sunset = testDateTime
+            this.dusk = testDateTime
+        }
+        SkylightDay.AlwaysDaytime::class -> SkylightDay.AlwaysDaytime { this.date = date }
+        SkylightDay.NeverLight::class -> SkylightDay.NeverLight { this.date = date }
         else -> throw IllegalArgumentException("Unknown ${SkylightDay::class} subtype: $this")
     }
 }

--- a/skylight/src/test/java/drewhamilton/skylight/SkylightTest.kt
+++ b/skylight/src/test/java/drewhamilton/skylight/SkylightTest.kt
@@ -24,11 +24,29 @@ class SkylightTest {
     private val betweenDawnAndDusk = ZonedDateTime.of(testDate, testSunrise.plusHours(2).toLocalTime(), ZoneOffset.UTC)
     private val afterDusk = ZonedDateTime.of(testDate, testDusk.plusHours(2).toLocalTime(), ZoneOffset.UTC)
 
-    private val testAlwaysDaytime = SkylightDay.AlwaysDaytime(testDate)
-    private val testAlwaysLight = SkylightDay.AlwaysLight(testSunrise, testSunset)
-    private val testNeverLight = SkylightDay.NeverLight(testDate)
-    private val testNeverDaytime = SkylightDay.NeverDaytime(testDawn, testDusk)
-    private val testTypical = SkylightDay.Typical(testDawn, testSunrise, testSunset, testDusk)
+    private val testAlwaysDaytime = SkylightDay.AlwaysDaytime { date = testDate }
+    private val testAlwaysLight = SkylightDay.Typical {
+        date = testDate
+        dawn = null
+        sunrise = testSunrise
+        sunset = testSunset
+        dusk = null
+    }
+    private val testNeverLight = SkylightDay.NeverLight { date = testDate }
+    private val testNeverDaytime = SkylightDay.Typical {
+        date = testDate
+        dawn = testDawn
+        sunrise = null
+        sunset = null
+        dusk = testDusk
+    }
+    private val testTypical = SkylightDay.Typical {
+        date = testDate
+        dawn = testDawn
+        sunrise = testSunrise
+        sunset = testSunset
+        dusk = testDusk
+    }
 
     private lateinit var mockSkylight: Skylight
 

--- a/sso/src/main/java/drewhamilton/skylight/sso/SsoSkylight.kt
+++ b/sso/src/main/java/drewhamilton/skylight/sso/SsoSkylight.kt
@@ -43,25 +43,15 @@ class SsoSkylight @Inject constructor(
 internal fun SunriseSunsetInfo.toSkylightDay(date: LocalDate): SkylightDay {
     return when {
         civil_twilight_begin == ApiConstants.DATE_TIME_NONE && sunrise == ApiConstants.DATE_TIME_NONE ->
-            SkylightDay.NeverLight(date)
+            SkylightDay.NeverLight { this.date = date }
         civil_twilight_begin == ApiConstants.DATE_TIME_ALWAYS_DAY && sunrise == ApiConstants.DATE_TIME_ALWAYS_DAY ->
-            SkylightDay.AlwaysDaytime(date)
-        civil_twilight_begin == ApiConstants.DATE_TIME_NONE ->
-            SkylightDay.AlwaysLight(
-                sunrise.toZonedDateTime(),
-                sunset.toZonedDateTime()
-            )
-        sunrise == ApiConstants.DATE_TIME_NONE ->
-            SkylightDay.NeverDaytime(
-                civil_twilight_begin.toZonedDateTime(),
-                civil_twilight_end.toZonedDateTime()
-            )
-        else ->
-            SkylightDay.Typical(
-                civil_twilight_begin.toZonedDateTime(),
-                sunrise.toZonedDateTime(),
-                sunset.toZonedDateTime(),
-                civil_twilight_end.toZonedDateTime()
-            )
+            SkylightDay.AlwaysDaytime { this.date = date }
+        else -> SkylightDay.Typical {
+            this.date = date
+            this.dawn = civil_twilight_begin.toZonedDateTime()
+            this.sunrise = this@toSkylightDay.sunrise.toZonedDateTime()
+            this.sunset = this@toSkylightDay.sunset.toZonedDateTime()
+            this.dusk = civil_twilight_end.toZonedDateTime()
+        }
     }
 }

--- a/sso/src/main/java/drewhamilton/skylight/sso/SsoSkylight.kt
+++ b/sso/src/main/java/drewhamilton/skylight/sso/SsoSkylight.kt
@@ -17,7 +17,6 @@ import javax.inject.Inject
  * An implementation of [Skylight] that uses sunrise-sunset.org to determine a [SkylightDay] for the given location
  * and date.
  */
-@Suppress("NewApi")
 class SsoSkylight @Inject constructor(
     private val api: SsoApi
 ) : Skylight {

--- a/sso/src/main/java/drewhamilton/skylight/sso/network/SsoDateFormat.kt
+++ b/sso/src/main/java/drewhamilton/skylight/sso/network/SsoDateFormat.kt
@@ -3,9 +3,7 @@ package drewhamilton.skylight.sso.network
 import java.time.LocalDate
 import java.time.format.DateTimeFormatter
 
-@Suppress("NewApi")
 @SsoDate
 internal fun LocalDate.toSsoDateString() = DATE_FORMATTER.format(this)
 
-@Suppress("NewApi")
 private val DATE_FORMATTER: DateTimeFormatter by lazy { DateTimeFormatter.ISO_LOCAL_DATE }

--- a/sso/src/main/java/drewhamilton/skylight/sso/network/SsoDateTimeFormat.kt
+++ b/sso/src/main/java/drewhamilton/skylight/sso/network/SsoDateTimeFormat.kt
@@ -6,14 +6,12 @@ import java.time.format.DateTimeFormatter
 import java.time.format.DateTimeFormatterBuilder
 import java.time.format.ResolverStyle
 
-@Suppress("NewApi")
 internal fun @receiver:SsoDateTime String.toZonedDateTime() =
     if (this == ApiConstants.DATE_TIME_NONE || this == ApiConstants.DATE_TIME_ALWAYS_DAY)
         null
     else
         ZonedDateTime.parse(this, DATE_TIME_FORMATTER)
 
-@Suppress("NewApi")
 private val DATE_TIME_FORMATTER: DateTimeFormatter by lazy {
     DateTimeFormatterBuilder()
         .parseCaseInsensitive()

--- a/sso/src/main/java/drewhamilton/skylight/sso/network/SsoDateTimeFormat.kt
+++ b/sso/src/main/java/drewhamilton/skylight/sso/network/SsoDateTimeFormat.kt
@@ -7,7 +7,11 @@ import java.time.format.DateTimeFormatterBuilder
 import java.time.format.ResolverStyle
 
 @Suppress("NewApi")
-internal fun @receiver:SsoDateTime String.toZonedDateTime() = ZonedDateTime.parse(this, DATE_TIME_FORMATTER)
+internal fun @receiver:SsoDateTime String.toZonedDateTime() =
+    if (this == ApiConstants.DATE_TIME_NONE || this == ApiConstants.DATE_TIME_ALWAYS_DAY)
+        null
+    else
+        ZonedDateTime.parse(this, DATE_TIME_FORMATTER)
 
 @Suppress("NewApi")
 private val DATE_TIME_FORMATTER: DateTimeFormatter by lazy {

--- a/sso/src/main/java/drewhamilton/skylight/sso/network/response/SunriseSunsetInfo.kt
+++ b/sso/src/main/java/drewhamilton/skylight/sso/network/response/SunriseSunsetInfo.kt
@@ -2,6 +2,7 @@ package drewhamilton.skylight.sso.network.response
 
 import drewhamilton.skylight.sso.network.SsoDateTime
 
+// TODO: Convert to DSL thing
 data class SunriseSunsetInfo(
     @SsoDateTime val sunrise: String,
     @SsoDateTime val sunset: String,

--- a/sso/src/test/java/drewhamilton/skylight/sso/SunriseSunsetInfoConversionsTest.kt
+++ b/sso/src/test/java/drewhamilton/skylight/sso/SunriseSunsetInfoConversionsTest.kt
@@ -11,7 +11,7 @@ import java.time.ZonedDateTime
 class SunriseSunsetInfoConversionsTest {
 
     private val dateString = "2011-04-12"
-    private val date = LocalDate.parse(dateString)
+    private val testDate = LocalDate.parse(dateString)
     private val throwaway = ""
 
     @Test
@@ -22,8 +22,8 @@ class SunriseSunsetInfoConversionsTest {
             ApiConstants.DATE_TIME_NONE,
             throwaway
         )
-        val output = input.toSkylightDay(date)
-        assertEquals(SkylightDay.NeverLight(date), output)
+        val output = input.toSkylightDay(testDate)
+        assertEquals(SkylightDay.NeverLight { date = testDate }, output)
     }
 
     @Test
@@ -34,64 +34,67 @@ class SunriseSunsetInfoConversionsTest {
             ApiConstants.DATE_TIME_ALWAYS_DAY,
             throwaway
         )
-        val output = input.toSkylightDay(date)
-        assertEquals(SkylightDay.AlwaysDaytime(date), output)
+        val output = input.toSkylightDay(testDate)
+        assertEquals(SkylightDay.AlwaysDaytime { date = testDate }, output)
     }
 
     @Test
     fun `toSkylightDay with only twilight begin NONE returns AlwaysLight`() {
         val sunriseTimeString = "07:01:23+00:00"
-        val sunrise = dateTimeString(sunriseTimeString)
+        val testSunrise = dateTimeString(sunriseTimeString)
         val sunsetTimeString = "18:54:32+00:00"
-        val sunset = dateTimeString(sunsetTimeString)
+        val testSunset = dateTimeString(sunsetTimeString)
 
-        val input = SunriseSunsetInfo(sunrise, sunset, ApiConstants.DATE_TIME_NONE, throwaway)
-        val output = input.toSkylightDay(date)
+        val input = SunriseSunsetInfo(testSunrise, testSunset, ApiConstants.DATE_TIME_NONE, ApiConstants.DATE_TIME_NONE)
+        val output = input.toSkylightDay(testDate)
 
-        val expected = SkylightDay.AlwaysLight(
-            ZonedDateTime.parse(sunrise),
-            ZonedDateTime.parse(sunset)
-        )
+        val expected = SkylightDay.Typical {
+            date = testDate
+            sunrise = ZonedDateTime.parse(testSunrise)
+            sunset = ZonedDateTime.parse(testSunset)
+        }
         assertEquals(expected, output)
     }
 
     @Test
     fun `toSkylightDay with only sunrise NONE returns NeverDaytime`() {
         val dawnTimeString = "06:01:23+00:00"
-        val dawn = dateTimeString(dawnTimeString)
+        val testDawn = dateTimeString(dawnTimeString)
         val duskTimeString = "18:54:32+00:00"
-        val dusk = dateTimeString(duskTimeString)
+        val testDusk = dateTimeString(duskTimeString)
 
-        val input = SunriseSunsetInfo(ApiConstants.DATE_TIME_NONE, throwaway, dawn, dusk)
-        val output = input.toSkylightDay(date)
+        val input = SunriseSunsetInfo(ApiConstants.DATE_TIME_NONE, ApiConstants.DATE_TIME_NONE, testDawn, testDusk)
+        val output = input.toSkylightDay(testDate)
 
-        val expected = SkylightDay.NeverDaytime(
-            ZonedDateTime.parse(dawn),
-            ZonedDateTime.parse(dusk)
-        )
+        val expected = SkylightDay.Typical {
+            date = testDate
+            dawn = ZonedDateTime.parse(testDawn)
+            dusk = ZonedDateTime.parse(testDusk)
+        }
         assertEquals(expected, output)
     }
 
     @Test
     fun `toSkylightDay with no special inputs returns Typical`() {
         val dawnTimeString = "06:01:23+00:00"
-        val dawn = dateTimeString(dawnTimeString)
+        val testDawn = dateTimeString(dawnTimeString)
         val sunriseTimeString = "07:01:23+00:00"
-        val sunrise = dateTimeString(sunriseTimeString)
+        val testSunrise = dateTimeString(sunriseTimeString)
         val sunsetTimeString = "18:54:32+00:00"
-        val sunset = dateTimeString(sunsetTimeString)
+        val testSunset = dateTimeString(sunsetTimeString)
         val duskTimeString = "18:54:32+00:00"
-        val dusk = dateTimeString(duskTimeString)
+        val testDusk = dateTimeString(duskTimeString)
 
-        val input = SunriseSunsetInfo(sunrise, sunset, dawn, dusk)
-        val output = input.toSkylightDay(date)
+        val input = SunriseSunsetInfo(testSunrise, testSunset, testDawn, testDusk)
+        val output = input.toSkylightDay(testDate)
 
-        val expected = SkylightDay.Typical(
-            ZonedDateTime.parse(dawn),
-            ZonedDateTime.parse(sunrise),
-            ZonedDateTime.parse(sunset),
-            ZonedDateTime.parse(dusk)
-        )
+        val expected = SkylightDay.Typical {
+            date = testDate
+            dawn = ZonedDateTime.parse(testDawn)
+            sunrise = ZonedDateTime.parse(testSunrise)
+            sunset = ZonedDateTime.parse(testSunset)
+            dusk = ZonedDateTime.parse(testDusk)
+        }
         assertEquals(expected, output)
     }
 


### PR DESCRIPTION
A frequent annoyance with the 0.10.0 and earlier API was constantly unwrapping the sealed `SkylightDay` class and repeating logic for `Typical`, `NeverDaytime`, and `AlwaysLight` SkylightDays (because each of the dawn, sunrise, sunset, and dusk events was duplicated). Furthermore, the API could not cover "transition" day edge cases, e.g. when a day has a dawn but not a dusk because it's way far north and summer is approaching.

Now, `NeverDaytime` and `AlwaysLight` are removed, and instead, all 4 events in `Typical` are nullable. Now the entire problem space is fully representable and duplicate logic in consumers is far less likely to be necessary. `AlwaysDaytime` and `NeverLight` remain, because they both have no events and thus must be distinctly represented.

Finally, each SkylightDay is redesigned with [Jake Wharton's value class model](https://jakewharton.com/public-api-challenges-in-kotlin/) to avoid API maintenance issues with data classes.