### PR TITLE
Add Extra Care

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -24,15 +24,24 @@ buildscript {
         classpath 'org.jetbrains.kotlinx:binary-compatibility-validator:0.2.3'
 
         classpath 'dev.drewhamilton.extracare:extracare-gradle-plugin:0.2.2'
+
+        classpath 'com.android.tools.build:gradle:3.6.3'
     }
     repositories {
         mavenCentral()
         maven { url = 'https://kotlin.bintray.com/kotlinx' }
         maven { url = 'https://dl.bintray.com/kotlin/dokka' }
+
+        // Android:
+        google()
+        maven { url = 'https://jetbrains.bintray.com/trove4j' }
     }
 }
 
 apply plugin: 'binary-compatibility-validator'
+apiValidation {
+    ignoredProjects += ['nothing']
+}
 
 ext {
     libraryVersion = '0.12.0-SNAPSHOT'
@@ -42,6 +51,10 @@ allprojects {
     repositories {
         mavenCentral()
         maven { url = 'https://dl.bintray.com/kotlin/dokka' }
+
+        // Android:
+        google()
+        maven { url = 'https://jetbrains.bintray.com/trove4j' }
     }
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -22,6 +22,8 @@ buildscript {
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$versions.kotlin"
         classpath 'org.jetbrains.dokka:dokka-gradle-plugin:0.10.1'
         classpath 'org.jetbrains.kotlinx:binary-compatibility-validator:0.2.3'
+
+        classpath 'dev.drewhamilton.extracare:extracare-gradle-plugin:0.2.2'
     }
     repositories {
         mavenCentral()

--- a/nothing/build.gradle
+++ b/nothing/build.gradle
@@ -1,0 +1,10 @@
+apply plugin: 'com.android.library'
+
+android {
+    compileSdkVersion 29
+    defaultConfig {
+        minSdkVersion 29
+        targetSdkVersion 29
+        versionName "0.0"
+    }
+}

--- a/nothing/src/main/AndroidManifest.xml
+++ b/nothing/src/main/AndroidManifest.xml
@@ -1,0 +1,2 @@
+<manifest
+    package="dev.drewhamilton.skylight.nothing" />

--- a/settings.gradle
+++ b/settings.gradle
@@ -1,2 +1,3 @@
 include ':skylight'
 include ':calculator', ':dummy', ':sso'
+include ':nothing'

--- a/skylight/build.gradle
+++ b/skylight/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'java-library'
 apply plugin: 'org.jetbrains.kotlin.jvm'
-apply plugin: 'org.jetbrains.kotlin.kapt'
+apply plugin: 'dev.drewhamilton.extracare'
 
 ext {
     artifactName = 'skylight'

--- a/skylight/src/main/java/dev/drewhamilton/skylight/SkylightDay.kt
+++ b/skylight/src/main/java/dev/drewhamilton/skylight/SkylightDay.kt
@@ -1,5 +1,6 @@
 package dev.drewhamilton.skylight
 
+import dev.drewhamilton.extracare.DataApi
 import java.time.LocalDate
 import java.time.ZonedDateTime
 import java.util.Objects
@@ -27,22 +28,13 @@ sealed class SkylightDay {
      * It should never be the case that all 4 event values are null. In those cases where a day does not have any of
      * these events, either [AlwaysDaytime] or [NeverLight] should be used.
      */
-    class Typical private constructor(
+    @DataApi class Typical private constructor(
         override val date: LocalDate,
         val dawn: ZonedDateTime?,
         val sunrise: ZonedDateTime?,
         val sunset: ZonedDateTime?,
         val dusk: ZonedDateTime?
     ) : SkylightDay() {
-        override fun toString() =
-            "SkylightDay.Typical(date=$date, dawn=$dawn, sunrise=$sunrise, sunset=$sunset, dusk=$dusk)"
-        override fun equals(other: Any?) = other is Typical &&
-                date == other.date &&
-                dawn == other.dawn &&
-                sunrise == other.sunrise &&
-                sunset == other.sunset &&
-                dusk == other.dusk
-        override fun hashCode() = Objects.hash(date, dawn, sunrise, sunset, dusk)
 
         class Builder {
             @set:JvmSynthetic
@@ -79,11 +71,10 @@ sealed class SkylightDay {
     /**
      * Represents a day wherein the sun never goes below the horizon.
      */
-    class AlwaysDaytime private constructor(
+    @Suppress("EqualsOrHashCode") // Equals is generated
+    @DataApi class AlwaysDaytime private constructor(
         override val date: LocalDate
     ) : SkylightDay() {
-        override fun toString() = "SkylightDay.AlwaysDaytime(date=$date)"
-        override fun equals(other: Any?) = other is AlwaysDaytime && date == other.date
         // Constant "1" ensures hash code is unique from NeverLight:
         override fun hashCode() = Objects.hash(1, date)
 
@@ -103,11 +94,10 @@ sealed class SkylightDay {
     /**
      * Represents a day that is always dark, i.e. the sun never goes above civil twilight.
      */
-    class NeverLight private constructor(
+    @Suppress("EqualsOrHashCode") // Equals is generated
+    @DataApi class NeverLight private constructor(
         override val date: LocalDate
     ) : SkylightDay() {
-        override fun toString() = "SkylightDay.NeverLight(date=$date)"
-        override fun equals(other: Any?) = other is NeverLight && date == other.date
         // Constant "2" ensures hash code is unique from AlwaysDaytime:
         override fun hashCode() = Objects.hash(2, date)
 

--- a/skylight/src/test/java/dev/drewhamilton/skylight/SkylightDayTest.kt
+++ b/skylight/src/test/java/dev/drewhamilton/skylight/SkylightDayTest.kt
@@ -84,7 +84,7 @@ class SkylightDayTest {
             sunset = ZonedDateTime.parse("2020-01-13T18:00:00+02:00")
             dusk = ZonedDateTime.parse("2020-01-13T20:00:00+02:00")
         }
-        val expected = "SkylightDay.Typical(" +
+        val expected = "Typical(" +
                 "date=${day.date}, dawn=${day.dawn}, sunrise=${day.sunrise}, sunset=${day.sunset}, dusk=${day.dusk}" +
                 ")"
         assertEquals(expected, day.toString())
@@ -131,7 +131,7 @@ class SkylightDayTest {
         val day = SkylightDay.AlwaysDaytime {
             date = LocalDate.parse("2020-01-13")
         }
-        val expected = "SkylightDay.AlwaysDaytime(date=${day.date})"
+        val expected = "AlwaysDaytime(date=${day.date})"
         assertEquals(expected, day.toString())
     }
     //endregion
@@ -176,7 +176,7 @@ class SkylightDayTest {
         val day = SkylightDay.NeverLight {
             date = LocalDate.parse("2020-01-13")
         }
-        val expected = "SkylightDay.NeverLight(date=${day.date})"
+        val expected = "NeverLight(date=${day.date})"
         assertEquals(expected, day.toString())
     }
     //endregion


### PR DESCRIPTION
Replace manual equals/toStrings by using `@DataApi`.

The IDE (IntelliJ IDEA CE 2020.1.1) throws an error when trying to enable Extra Care unless the Android plugin is also applied. There's probably a less dumb way to work around this in a non-Android project but I don't know what it is. So the `:nothing` module is added to do this.