### PR TITLE
Convert `isLight` and friends to use an Instant 

### DIFF
--- a/calculator/src/test/java/dev/drewhamilton/skylight/calculator/CalculatorSkylightTest.kt
+++ b/calculator/src/test/java/dev/drewhamilton/skylight/calculator/CalculatorSkylightTest.kt
@@ -56,7 +56,7 @@ class CalculatorSkylightTest {
             "Expected it to be light in Indianapolis at noon.",
             skylight.isLight(
                 INDIANAPOLIS,
-                ZonedDateTime.of(JULY_20_2019, LocalTime.NOON, ZoneId.of("America/New_York"))
+                ZonedDateTime.of(JULY_20_2019, LocalTime.NOON, ZoneId.of("America/New_York")).toInstant()
             )
         )
     }

--- a/skylight/api/skylight.api
+++ b/skylight/api/skylight.api
@@ -67,10 +67,10 @@ public final class dev/drewhamilton/skylight/SkylightForDateKt {
 }
 
 public final class dev/drewhamilton/skylight/SkylightLightness {
-	public static final fun isDark (Ldev/drewhamilton/skylight/Skylight;Ldev/drewhamilton/skylight/Coordinates;Ljava/time/ZonedDateTime;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun isDark (Ldev/drewhamilton/skylight/SkylightForCoordinates;Ljava/time/ZonedDateTime;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun isDaytime (Ldev/drewhamilton/skylight/Skylight;Ldev/drewhamilton/skylight/Coordinates;Ljava/time/ZonedDateTime;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun isLight (Ldev/drewhamilton/skylight/Skylight;Ldev/drewhamilton/skylight/Coordinates;Ljava/time/ZonedDateTime;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
-	public static final fun isLight (Ldev/drewhamilton/skylight/SkylightForCoordinates;Ljava/time/ZonedDateTime;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun isDark (Ldev/drewhamilton/skylight/Skylight;Ldev/drewhamilton/skylight/Coordinates;Ljava/time/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun isDark (Ldev/drewhamilton/skylight/SkylightForCoordinates;Ljava/time/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun isDaytime (Ldev/drewhamilton/skylight/Skylight;Ldev/drewhamilton/skylight/Coordinates;Ljava/time/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun isLight (Ldev/drewhamilton/skylight/Skylight;Ldev/drewhamilton/skylight/Coordinates;Ljava/time/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
+	public static final fun isLight (Ldev/drewhamilton/skylight/SkylightForCoordinates;Ljava/time/Instant;Lkotlin/coroutines/Continuation;)Ljava/lang/Object;
 }
 

--- a/skylight/src/main/java/dev/drewhamilton/skylight/Lightness.kt
+++ b/skylight/src/main/java/dev/drewhamilton/skylight/Lightness.kt
@@ -2,55 +2,57 @@
 package dev.drewhamilton.skylight
 
 import java.time.Instant
-import java.time.ZonedDateTime
+import java.time.ZoneOffset
 
 //region Skylight
 /**
- * Determine whether it is light outside at the given [coordinates] at the given [dateTime], where "light" means after
- * dawn and before dusk on the given date.
+ * Determine whether it is light outside at the given [coordinates] at the given [instant], where "light" means after
+ * dawn and before dusk.
+ *
+ * To determine whether an instant is after sunrise and before sunset, see [isDaytime].
  */
-suspend fun Skylight.isLight(coordinates: Coordinates, dateTime: ZonedDateTime): Boolean =
-    when (val skylightDay = getSkylightDay(coordinates, dateTime.toLocalDate())) {
+suspend fun Skylight.isLight(coordinates: Coordinates, instant: Instant): Boolean =
+    when (val skylightDay = getSkylightDay(coordinates, instant.atOffset(ZoneOffset.UTC).toLocalDate())) {
         is SkylightDay.AlwaysDaytime -> true
         is SkylightDay.NeverLight -> false
-        is SkylightDay.Typical -> skylightDay.isLightAt(dateTime.toInstant())
+        is SkylightDay.Typical -> skylightDay.isLightAt(instant)
     }
 
 /**
- * Determine whether it is dark outside at the given [coordinates] at the given [dateTime], where "dark" means before
- * dawn or after dusk on the given date.
+ * Determine whether it is dark outside at the given [coordinates] at the given [instant], where "dark" means before
+ * dawn or after dusk.
+ *
+ * To determine an instant's relationship to sunrise and sunset, see [isDaytime].
  */
-suspend fun Skylight.isDark(coordinates: Coordinates, dateTime: ZonedDateTime): Boolean =
-    !isLight(coordinates, dateTime)
+suspend fun Skylight.isDark(coordinates: Coordinates, instant: Instant): Boolean =
+    !isLight(coordinates, instant)
 
 /**
- * Determine whether it is daytime at the given [coordinates] at the given [dateTime], where "daytime" means after
- * sunrise and before sunset on the given date.
+ * Determine whether it is daytime at the given [coordinates] at the given [instant], where "daytime" means after
+ * sunrise and before sunset.
+ *
+ * To determine an instant's relationship to dawn and dusk, see [isLight] and [isDark].
  */
-suspend fun Skylight.isDaytime(coordinates: Coordinates, dateTime: ZonedDateTime): Boolean =
-    when (val skylightDay = getSkylightDay(coordinates, dateTime.toLocalDate())) {
+suspend fun Skylight.isDaytime(coordinates: Coordinates, instant: Instant): Boolean =
+    when (val skylightDay = getSkylightDay(coordinates, instant.atOffset(ZoneOffset.UTC).toLocalDate())) {
         is SkylightDay.AlwaysDaytime -> true
         is SkylightDay.NeverLight -> false
-        is SkylightDay.Typical -> skylightDay.isDaytimeAt(dateTime.toInstant())
+        is SkylightDay.Typical -> skylightDay.isDaytimeAt(instant)
     }
 //endregion
 
 //region SkylightForCoordinates
 /**
- * @param dateTime The date-time at which to check for lightness.
- * @return Whether it is light outside at the [SkylightForCoordinates]'s coordinates at the given date-time, where
- * "light" means after dawn and before dusk on the given date.
+ * Determine whether it is light outside at the given [instant], where "light" means after dawn and before dusk.
  */
-suspend fun SkylightForCoordinates.isLight(dateTime: ZonedDateTime): Boolean =
-    skylight.isLight(coordinates, dateTime)
+suspend fun SkylightForCoordinates.isLight(instant: Instant): Boolean =
+    skylight.isLight(coordinates, instant)
 
 /**
- * @param dateTime The date-time at which to check for darkness.
- * @return Whether it is dark outside at the [SkylightForCoordinates]'s coordinates at the given date-time, where "dark"
- * means before dawn or after dusk on the given date.
+ * Determine whether it is dark outside at the given [instant], where "dark" means before dawn or after dusk.
  */
-suspend fun SkylightForCoordinates.isDark(dateTime: ZonedDateTime): Boolean =
-    skylight.isDark(coordinates, dateTime)
+suspend fun SkylightForCoordinates.isDark(instant: Instant): Boolean =
+    skylight.isDark(coordinates, instant)
 //endregion
 
 private fun SkylightDay.Typical.isLightAt(instant: Instant) =

--- a/skylight/src/test/java/dev/drewhamilton/skylight/SkylightForCoordinatesTest.kt
+++ b/skylight/src/test/java/dev/drewhamilton/skylight/SkylightForCoordinatesTest.kt
@@ -32,12 +32,12 @@ class SkylightForCoordinatesTest {
     }
 
     @Test fun `isLight returns result based on Skylight`() = runTest {
-        assertTrue(skylightForCoordinates.isLight(testDateTime1))
-        assertFalse(skylightForCoordinates.isLight(testDateTime2))
+        assertTrue(skylightForCoordinates.isLight(testDateTime1.toInstant()))
+        assertFalse(skylightForCoordinates.isLight(testDateTime2.toInstant()))
     }
 
     @Test fun `isDark returns result based on Skylight`() = runTest {
-        assertFalse(skylightForCoordinates.isDark(testDateTime1))
-        assertTrue(skylightForCoordinates.isDark(testDateTime2))
+        assertFalse(skylightForCoordinates.isDark(testDateTime1.toInstant()))
+        assertTrue(skylightForCoordinates.isDark(testDateTime2.toInstant()))
     }
 }

--- a/skylight/src/test/java/dev/drewhamilton/skylight/SkylightTest.kt
+++ b/skylight/src/test/java/dev/drewhamilton/skylight/SkylightTest.kt
@@ -63,133 +63,133 @@ class SkylightTest {
 
     //region isLight
     @Test fun `isLight with AlwaysDaytime returns true`() = runTest {
-        assertTrue(skylight.isLight(testCoordinates, beforeDawn.withDate(alwaysDaytimeDate)))
-        assertTrue(skylight.isLight(testCoordinates, betweenSunriseAndSunset.withDate(alwaysDaytimeDate)))
-        assertTrue(skylight.isLight(testCoordinates, afterDusk.withDate(alwaysDaytimeDate)))
+        assertTrue(skylight.isLight(testCoordinates, beforeDawn.withDate(alwaysDaytimeDate).toInstant()))
+        assertTrue(skylight.isLight(testCoordinates, betweenSunriseAndSunset.withDate(alwaysDaytimeDate).toInstant()))
+        assertTrue(skylight.isLight(testCoordinates, afterDusk.withDate(alwaysDaytimeDate).toInstant()))
     }
 
     @Test fun `isLight with AlwaysLight returns true`() = runTest {
-        assertTrue(skylight.isLight(testCoordinates, beforeDawn.withDate(alwaysLightDate)))
-        assertTrue(skylight.isLight(testCoordinates, betweenSunriseAndSunset.withDate(alwaysLightDate)))
-        assertTrue(skylight.isLight(testCoordinates, afterDusk.withDate(alwaysLightDate)))
+        assertTrue(skylight.isLight(testCoordinates, beforeDawn.withDate(alwaysLightDate).toInstant()))
+        assertTrue(skylight.isLight(testCoordinates, betweenSunriseAndSunset.withDate(alwaysLightDate).toInstant()))
+        assertTrue(skylight.isLight(testCoordinates, afterDusk.withDate(alwaysLightDate).toInstant()))
     }
 
     @Test fun `isLight with NeverLight returns false`() = runTest {
-        assertFalse(skylight.isLight(testCoordinates, beforeDawn.withDate(neverLightDate)))
-        assertFalse(skylight.isLight(testCoordinates, betweenSunriseAndSunset.withDate(neverLightDate)))
-        assertFalse(skylight.isLight(testCoordinates, afterDusk.withDate(neverLightDate)))
+        assertFalse(skylight.isLight(testCoordinates, beforeDawn.withDate(neverLightDate).toInstant()))
+        assertFalse(skylight.isLight(testCoordinates, betweenSunriseAndSunset.withDate(neverLightDate).toInstant()))
+        assertFalse(skylight.isLight(testCoordinates, afterDusk.withDate(neverLightDate).toInstant()))
     }
 
     @Test fun `isLight with NeverDaytime returns false before dawn`() = runTest {
-        assertFalse(skylight.isLight(testCoordinates, beforeDawn.withDate(neverDaytimeDate)))
+        assertFalse(skylight.isLight(testCoordinates, beforeDawn.withDate(neverDaytimeDate).toInstant()))
     }
 
     @Test fun `isLight with NeverDaytime returns true between dawn and dusk`() = runTest {
-        assertTrue(skylight.isLight(testCoordinates, betweenSunriseAndSunset.withDate(neverDaytimeDate)))
+        assertTrue(skylight.isLight(testCoordinates, betweenSunriseAndSunset.withDate(neverDaytimeDate).toInstant()))
     }
 
     @Test fun `isLight with NeverDaytime returns false after dusk`() = runTest {
-        assertFalse(skylight.isLight(testCoordinates, afterDusk.withDate(neverDaytimeDate)))
+        assertFalse(skylight.isLight(testCoordinates, afterDusk.withDate(neverDaytimeDate).toInstant()))
     }
 
     @Test fun `isLight with Typical returns false before dawn`() = runTest {
-        assertFalse(skylight.isLight(testCoordinates, beforeDawn.withDate(typicalDate)))
+        assertFalse(skylight.isLight(testCoordinates, beforeDawn.withDate(typicalDate).toInstant()))
     }
 
     @Test fun `isLight with Typical returns true between dawn and dusk`() = runTest {
-        assertTrue(skylight.isLight(testCoordinates, betweenSunriseAndSunset.withDate(typicalDate)))
+        assertTrue(skylight.isLight(testCoordinates, betweenSunriseAndSunset.withDate(typicalDate).toInstant()))
     }
 
     @Test fun `isLight with Typical returns false after dusk`() = runTest {
-        assertFalse(skylight.isLight(testCoordinates, afterDusk.withDate(typicalDate)))
+        assertFalse(skylight.isLight(testCoordinates, afterDusk.withDate(typicalDate).toInstant()))
     }
     //endregion
 
     //region isDark
     @Test fun `isDark with AlwaysDaytime returns false`() = runTest {
-        assertFalse(skylight.isDark(testCoordinates, beforeDawn.withDate(alwaysDaytimeDate)))
-        assertFalse(skylight.isDark(testCoordinates, betweenSunriseAndSunset.withDate(alwaysDaytimeDate)))
-        assertFalse(skylight.isDark(testCoordinates, afterDusk.withDate(alwaysDaytimeDate)))
+        assertFalse(skylight.isDark(testCoordinates, beforeDawn.withDate(alwaysDaytimeDate).toInstant()))
+        assertFalse(skylight.isDark(testCoordinates, betweenSunriseAndSunset.withDate(alwaysDaytimeDate).toInstant()))
+        assertFalse(skylight.isDark(testCoordinates, afterDusk.withDate(alwaysDaytimeDate).toInstant()))
     }
 
     @Test fun `isDark with AlwaysLight returns false`() = runTest {
-        assertFalse(skylight.isDark(testCoordinates, beforeDawn.withDate(alwaysLightDate)))
-        assertFalse(skylight.isDark(testCoordinates, betweenSunriseAndSunset.withDate(alwaysLightDate)))
-        assertFalse(skylight.isDark(testCoordinates, afterDusk.withDate(alwaysLightDate)))
+        assertFalse(skylight.isDark(testCoordinates, beforeDawn.withDate(alwaysLightDate).toInstant()))
+        assertFalse(skylight.isDark(testCoordinates, betweenSunriseAndSunset.withDate(alwaysLightDate).toInstant()))
+        assertFalse(skylight.isDark(testCoordinates, afterDusk.withDate(alwaysLightDate).toInstant()))
     }
 
     @Test fun `isDark with NeverLight returns true`() = runTest {
-        assertTrue(skylight.isDark(testCoordinates, beforeDawn.withDate(neverLightDate)))
-        assertTrue(skylight.isDark(testCoordinates, betweenSunriseAndSunset.withDate(neverLightDate)))
-        assertTrue(skylight.isDark(testCoordinates, afterDusk.withDate(neverLightDate)))
+        assertTrue(skylight.isDark(testCoordinates, beforeDawn.withDate(neverLightDate).toInstant()))
+        assertTrue(skylight.isDark(testCoordinates, betweenSunriseAndSunset.withDate(neverLightDate).toInstant()))
+        assertTrue(skylight.isDark(testCoordinates, afterDusk.withDate(neverLightDate).toInstant()))
     }
 
     @Test fun `isDark with NeverDaytime returns true before dawn`() = runTest {
-        assertTrue(skylight.isDark(testCoordinates, beforeDawn.withDate(neverDaytimeDate)))
+        assertTrue(skylight.isDark(testCoordinates, beforeDawn.withDate(neverDaytimeDate).toInstant()))
     }
 
     @Test fun `isDark with NeverDaytime returns false between dawn and dusk`() = runTest {
-        assertFalse(skylight.isDark(testCoordinates, betweenSunriseAndSunset.withDate(neverDaytimeDate)))
+        assertFalse(skylight.isDark(testCoordinates, betweenSunriseAndSunset.withDate(neverDaytimeDate).toInstant()))
     }
 
     @Test fun `isDark with NeverDaytime returns true after dusk`() = runTest {
-        assertTrue(skylight.isDark(testCoordinates, afterDusk.withDate(neverDaytimeDate)))
+        assertTrue(skylight.isDark(testCoordinates, afterDusk.withDate(neverDaytimeDate).toInstant()))
     }
 
     @Test fun `isDark with Typical returns true before dawn`() = runTest {
-        assertTrue(skylight.isDark(testCoordinates, beforeDawn.withDate(typicalDate)))
+        assertTrue(skylight.isDark(testCoordinates, beforeDawn.withDate(typicalDate).toInstant()))
     }
 
     @Test fun `isDark with Typical returns false between dawn and dusk`() = runTest {
-        assertFalse(skylight.isDark(testCoordinates, betweenSunriseAndSunset.withDate(typicalDate)))
+        assertFalse(skylight.isDark(testCoordinates, betweenSunriseAndSunset.withDate(typicalDate).toInstant()))
     }
 
     @Test fun `isDark with Typical returns true after dusk`() = runTest {
-        assertTrue(skylight.isDark(testCoordinates, afterDusk.withDate(typicalDate)))
+        assertTrue(skylight.isDark(testCoordinates, afterDusk.withDate(typicalDate).toInstant()))
     }
     //endregion
 
     //region isDaytime
     @Test fun `isDaytime with AlwaysDaytime returns true`() = runTest {
-        assertTrue(skylight.isDaytime(testCoordinates, beforeDawn.withDate(alwaysDaytimeDate)))
-        assertTrue(skylight.isDaytime(testCoordinates, betweenSunriseAndSunset.withDate(alwaysDaytimeDate)))
-        assertTrue(skylight.isDaytime(testCoordinates, afterDusk.withDate(alwaysDaytimeDate)))
+        assertTrue(skylight.isDaytime(testCoordinates, beforeDawn.withDate(alwaysDaytimeDate).toInstant()))
+        assertTrue(skylight.isDaytime(testCoordinates, betweenSunriseAndSunset.withDate(alwaysDaytimeDate).toInstant()))
+        assertTrue(skylight.isDaytime(testCoordinates, afterDusk.withDate(alwaysDaytimeDate).toInstant()))
     }
 
     @Test fun `isDaytime with AlwaysLight returns false before sunrise`() = runTest {
-        assertFalse(skylight.isDaytime(testCoordinates, beforeSunrise.withDate(alwaysLightDate)))
+        assertFalse(skylight.isDaytime(testCoordinates, beforeSunrise.withDate(alwaysLightDate).toInstant()))
     }
 
     @Test fun `isDaytime with AlwaysLight returns true between sunrise and sunset`() = runTest {
-        assertTrue(skylight.isDaytime(testCoordinates, betweenSunriseAndSunset.withDate(alwaysLightDate)))
+        assertTrue(skylight.isDaytime(testCoordinates, betweenSunriseAndSunset.withDate(alwaysLightDate).toInstant()))
     }
 
     @Test fun `isDaytime with AlwaysLight returns false after sunset`() = runTest {
-        assertFalse(skylight.isDaytime(testCoordinates, afterDusk.withDate(alwaysLightDate)))
+        assertFalse(skylight.isDaytime(testCoordinates, afterDusk.withDate(alwaysLightDate).toInstant()))
     }
 
     @Test fun `isDaytime with NeverLight returns false`() = runTest {
-        assertFalse(skylight.isDaytime(testCoordinates, beforeDawn.withDate(neverLightDate)))
-        assertFalse(skylight.isDaytime(testCoordinates, betweenSunriseAndSunset.withDate(neverLightDate)))
-        assertFalse(skylight.isDaytime(testCoordinates, afterDusk.withDate(neverLightDate)))
+        assertFalse(skylight.isDaytime(testCoordinates, beforeDawn.withDate(neverLightDate).toInstant()))
+        assertFalse(skylight.isDaytime(testCoordinates, betweenSunriseAndSunset.withDate(neverLightDate).toInstant()))
+        assertFalse(skylight.isDaytime(testCoordinates, afterDusk.withDate(neverLightDate).toInstant()))
     }
 
     @Test fun `isDaytime with NeverDaytime returns false`() = runTest {
-        assertFalse(skylight.isDaytime(testCoordinates, beforeSunrise.withDate(neverDaytimeDate)))
-        assertFalse(skylight.isDaytime(testCoordinates, betweenSunriseAndSunset.withDate(neverDaytimeDate)))
-        assertFalse(skylight.isDaytime(testCoordinates, afterSunset.withDate(neverDaytimeDate)))
+        assertFalse(skylight.isDaytime(testCoordinates, beforeSunrise.withDate(neverDaytimeDate).toInstant()))
+        assertFalse(skylight.isDaytime(testCoordinates, betweenSunriseAndSunset.withDate(neverDaytimeDate).toInstant()))
+        assertFalse(skylight.isDaytime(testCoordinates, afterSunset.withDate(neverDaytimeDate).toInstant()))
     }
 
     @Test fun `isDaytime with Typical returns false before sunrise`() = runTest {
-        assertFalse(skylight.isDaytime(testCoordinates, beforeSunrise.withDate(typicalDate)))
+        assertFalse(skylight.isDaytime(testCoordinates, beforeSunrise.withDate(typicalDate).toInstant()))
     }
 
     @Test fun `isDaytime with Typical returns true between sunrise and sunset`() = runTest {
-        assertTrue(skylight.isDaytime(testCoordinates, betweenSunriseAndSunset.withDate(typicalDate)))
+        assertTrue(skylight.isDaytime(testCoordinates, betweenSunriseAndSunset.withDate(typicalDate).toInstant()))
     }
 
     @Test fun `isDaytime with Typical returns false after sunset`() = runTest {
-        assertFalse(skylight.isDaytime(testCoordinates, afterSunset.withDate(typicalDate)))
+        assertFalse(skylight.isDaytime(testCoordinates, afterSunset.withDate(typicalDate).toInstant()))
     }
     //endregion
 


### PR DESCRIPTION
Rather than a ZonedDateTime, which is unnecessarily complex for this use-case. Closes #41.