### PR TITLE
okhttp 4.9.3

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 
 coroutines = "1.6.4"
 kotlin = "1.7.21"
-okhttp = "3.14.9"
+okhttp = "4.9.3"
 retrofit = "2.9.0"
 
 [libraries]

--- a/sunrise-sunset-org/src/main/java/dev/drewhamilton/skylight/sunrise_sunset_org/network/ApiConstants.kt
+++ b/sunrise-sunset-org/src/main/java/dev/drewhamilton/skylight/sunrise_sunset_org/network/ApiConstants.kt
@@ -1,10 +1,10 @@
 package dev.drewhamilton.skylight.sunrise_sunset_org.network
 
-import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 
 internal object ApiConstants {
 
-    internal val BASE_URL = HttpUrl.get("https://api.sunrise-sunset.org/")
+    internal val BASE_URL = "https://api.sunrise-sunset.org/".toHttpUrl()
 
     internal const val DATE_TIME_NONE = "1970-01-01T00:00:00+00:00"
     internal const val DATE_TIME_ALWAYS_DAY = "1970-01-01T00:00:01+00:00"

--- a/sunrise-sunset-org/src/test/java/dev/drewhamilton/skylight/sunrise_sunset_org/SunriseSunsetOrgSkylightTest.kt
+++ b/sunrise-sunset-org/src/test/java/dev/drewhamilton/skylight/sunrise_sunset_org/SunriseSunsetOrgSkylightTest.kt
@@ -12,7 +12,7 @@ import java.time.format.DateTimeFormatter
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import kotlinx.coroutines.test.runTest
 import okhttp3.OkHttpClient
-import okhttp3.ResponseBody
+import okhttp3.ResponseBody.Companion.toResponseBody
 import okhttp3.mockwebserver.MockResponse
 import okhttp3.mockwebserver.MockWebServer
 import org.junit.Assert.assertEquals
@@ -56,7 +56,7 @@ class SunriseSunsetOrgSkylightTest {
     @Test(expected = HttpException::class)
     fun `getInfo throws HttpException when API result is an error`() = runTest {
         val api = TestSunriseSunsetOrgApi(
-            testParams to Response.error(401, ResponseBody.create(null, "Content"))
+            testParams to Response.error(401, "Content".toResponseBody(null))
         )
         val sunriseSunsetOrgSkylight = SunriseSunsetOrgSkylight(api)
 
@@ -73,7 +73,7 @@ class SunriseSunsetOrgSkylightTest {
     @Test fun `retrofit with mock web server succeeds`() = runTest {
         val server = MockWebServer().apply {
             dispatcher = Dispatcher { request ->
-                val path = request.path
+                val path = request.path!!
                 when (path.substring(0, path.indexOf("?"))) {
                     "/json" -> successResponse.toMockResponse()
                     else -> MockResponse().setResponseCode(404)

--- a/sunrise-sunset-org/src/test/java/dev/drewhamilton/skylight/sunrise_sunset_org/network/ApiConstantsTest.kt
+++ b/sunrise-sunset-org/src/test/java/dev/drewhamilton/skylight/sunrise_sunset_org/network/ApiConstantsTest.kt
@@ -1,13 +1,13 @@
 package dev.drewhamilton.skylight.sunrise_sunset_org.network
 
-import okhttp3.HttpUrl
+import okhttp3.HttpUrl.Companion.toHttpUrl
 import org.junit.Assert.assertEquals
 import org.junit.Test
 
 class ApiConstantsTest {
 
     @Test fun `BASE_URL points to sunrise-sunset_org API`() {
-        assertEquals(HttpUrl.get("https://api.sunrise-sunset.org/"), ApiConstants.BASE_URL)
+        assertEquals("https://api.sunrise-sunset.org/".toHttpUrl(), ApiConstants.BASE_URL)
     }
 
     @Test fun `DATE_TIME_NONE is 1 Jan 1970 at midnight`() {


### PR DESCRIPTION
Sonatype was giving a [security warning](https://sbom.lift.sonatype.com/report/T1-a0368c8f29fdaa555824-58a1196245b72-1668213859-9fb5870e27084a2181f2ca737d49f417) for the previous version.